### PR TITLE
Add folder location display to Wox.Plugin.Folder

### DIFF
--- a/Plugins/Wox.Plugin.Folder/FolderLink.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderLink.cs
@@ -10,9 +10,9 @@ namespace Wox.Plugin.Folder
         [JsonProperty]
         public string Path { get; set; }
 
-        public string Nickname
-        {
-            get { return Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None).Last(); }
-        }
+        public string Nickname =>
+           Path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None)
+               .Last()
+           + " (" + System.IO.Path.GetDirectoryName(Path) + ")";
     }
 }


### PR DESCRIPTION
Context:
- Currently Wox.Plugin.Folder displays only the name of the folder, which is confusing to navigate when two or more folders have the same name. 

- The plugin does not handle folders with the same name despite being in different locations. Identified to be how objects are compared in Wox.Plugin => Result.cs => override bool Equals(Object obj). This method compares only title and subtitle where folders of the same name in different locations could have different IcoPath.

Enhancement:
Add each folder's directory location next to the name in the plugin title. Eg. each folder title will display 'Blah (C:\Temp\ParentBlahFolder)'