### PR TITLE
Wox.Plugin.URL- Open URL in new window browser

### DIFF
--- a/Plugins/Wox.Plugin.Url/Main.cs
+++ b/Plugins/Wox.Plugin.Url/Main.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
 using Wox.Infrastructure.Storage;
+using Wox.Plugin.SharedCommands;
 
 namespace Wox.Plugin.Url
 {
@@ -80,15 +79,8 @@ namespace Wox.Plugin.Url
                             }
                             try
                             {
-                                var browserExecutableName = _settings.BrowserPath?.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None).Last();
-
-                                var browser = string.IsNullOrEmpty(browserExecutableName) ? "chrome" : _settings.BrowserPath;
+                                raw.NewBrowserWindow(_settings.BrowserPath);
                                 
-                                // Internet Explorer will open url in new browser window, and does not take the --new-window parameter
-                                var browserArguements = browserExecutableName == "iexplore.exe" ? raw : "--new-window " + raw;
-
-                                Process.Start(browser, browserArguements);                                                               
-
                                 return true;
                             }
                             catch(Exception ex)

--- a/Plugins/Wox.Plugin.Url/Main.cs
+++ b/Plugins/Wox.Plugin.Url/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
@@ -85,7 +85,7 @@ namespace Wox.Plugin.Url
                                 }
                                 else
                                 {
-                                    Process.Start(_settings.BrowserPath,raw);
+                                    Process.Start(_settings.BrowserPath,"--new-window" + raw);
                                 }
 
                                 return true;

--- a/Plugins/Wox.Plugin.Url/Main.cs
+++ b/Plugins/Wox.Plugin.Url/Main.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
 using Wox.Infrastructure.Storage;
@@ -79,14 +80,14 @@ namespace Wox.Plugin.Url
                             }
                             try
                             {
-                                if (_settings.BrowserPath.Length == 0)
-                                {
-                                    Process.Start(raw);
-                                }
-                                else
-                                {
-                                    Process.Start(_settings.BrowserPath,"--new-window" + raw);
-                                }
+                                var browserExecutableName = _settings.BrowserPath?.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None).Last();
+
+                                var browser = string.IsNullOrEmpty(browserExecutableName) ? "chrome" : _settings.BrowserPath;
+                                
+                                // Internet Explorer will open url in new browser window, and does not take the --new-window parameter
+                                var browserArguements = browserExecutableName == "iexplore.exe" ? raw : "--new-window " + raw;
+
+                                Process.Start(browser, browserArguements);                                                               
 
                                 return true;
                             }

--- a/Wox.Plugin/SharedCommands/SearchWeb.cs
+++ b/Wox.Plugin/SharedCommands/SearchWeb.cs
@@ -3,14 +3,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
-namespace Wox.Plugin.WebSearch.Commands
+namespace Wox.Plugin.SharedCommands
 {
-    internal static class SearchWeb
+    public static class SearchWeb
     {
         /// <summary> Opens search in a new browser. If no browser path is passed in then Chrome is used. 
         /// Leave browser path blank to use Chrome.
         /// </summary>
-        internal static void NewBrowserWindow(this string url, string browserPath)
+        public static void NewBrowserWindow(this string url, string browserPath)
         {
             var browserExecutableName = browserPath?
                                         .Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.None)

--- a/Wox.Plugin/SharedCommands/SearchWeb.cs
+++ b/Wox.Plugin/SharedCommands/SearchWeb.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Wox.Plugin.WebSearch.Commands
+{
+    internal static class SearchWeb
+    {
+        /// <summary> Opens search in a new browser. If no browser path is passed in then Chrome is used. 
+        /// Leave browser path blank to use Chrome.
+        /// </summary>
+        internal static void NewBrowserWindow(this string url, string browserPath)
+        {
+            var browserExecutableName = browserPath?
+                                        .Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.None)
+                                        .Last();
+
+            var browser = string.IsNullOrEmpty(browserExecutableName) ? "chrome" : browserPath;
+
+            // Internet Explorer will open url in new browser window, and does not take the --new-window parameter
+            var browserArguements = browserExecutableName == "iexplore.exe" ? url : "--new-window " + url;
+
+            Process.Start(browser, browserArguements);
+        }
+    }
+}

--- a/Wox.Plugin/Wox.Plugin.csproj
+++ b/Wox.Plugin/Wox.Plugin.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Query.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="ActionContext.cs" />
+    <Compile Include="SharedCommands\SearchWeb.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -84,6 +85,7 @@
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Fody.1.29.2\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.2\build\dotnet\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
+    <PostBuildEvent>PowerShell -ExecutionPolicy Bypass -Command "$(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) '$(SolutionDir)'"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell.exe -NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>


### PR DESCRIPTION
-Fix bug when no browser path specified will throw exception, because code checks .Length == 0 instead of null. 

-Add open url in new browser window by default