### PR TITLE
Fix post_build.ps1 script failing due to PS ExecutionPolicy

### DIFF
--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
+    <PostBuildEvent>PowerShell -ExecutionPolicy Bypass -Command "$(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) '$(SolutionDir)'"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>PowerShell -ExecutionPolicy Bypass -Command "$(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) '$(SolutionDir)'"</PostBuildEvent>
+    <PostBuildEvent>PowerShell -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell.exe -NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>powershell -command "$policy = Get-ExecutionPolicy"; "Set-ExecutionPolicy RemoteSigned"; "'-NoProfile -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)'"; "Set-ExecutionPolicy $policy"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -462,7 +462,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>PowerShell -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>taskkill /f /fi "IMAGENAME eq Wox.exe"</PreBuildEvent>


### PR DESCRIPTION
Not the best security practice requiring user to set PowerShell execution policy to unrestricted as upstream readme.

This simple change adds the Bypass flag so when building the Wox solution do not need to explicitly set local PS environment to Unrestricted.