### PR TITLE
Enable portable mode

### DIFF
--- a/Wox.Infrastructure/Logger/Log.cs
+++ b/Wox.Infrastructure/Logger/Log.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using NLog;
@@ -22,8 +22,7 @@ namespace Wox.Infrastructure.Logger
             var configuration = new LoggingConfiguration();
             var target = new FileTarget();
             configuration.AddTarget("file", target);
-            target.FileName = "${specialfolder:folder=ApplicationData}/" + Constant.Wox + "/" + DirectoryName + "/" +
-                              Constant.Version + "/${shortdate}.txt";
+            target.FileName = path.Replace(@"\", "/") + "/${shortdate}.txt";
 #if DEBUG
             var rule = new LoggingRule("*", LogLevel.Debug, target);
 #else

--- a/Wox.Infrastructure/Wox.cs
+++ b/Wox.Infrastructure/Wox.cs
@@ -9,8 +9,6 @@ namespace Wox.Infrastructure
     {
         public static string DetermineDataDirectory()
         {
-            // use the method of VSCode to enable portable mode
-            // https://code.visualstudio.com/docs/editor/portable
             string portableDataPath = Path.Combine(ProgramDirectory, "UserData");
             if (Directory.Exists(portableDataPath))
             {

--- a/Wox.Infrastructure/Wox.cs
+++ b/Wox.Infrastructure/Wox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -7,13 +7,28 @@ namespace Wox.Infrastructure
 {
     public static class Constant
     {
+        public static string DetermineDataDirectory()
+        {
+            // use the method of VSCode to enable portable mode
+            // https://code.visualstudio.com/docs/editor/portable
+            string portableDataPath = Path.Combine(ProgramDirectory, "UserData");
+            if (Directory.Exists(portableDataPath))
+            {
+                return portableDataPath;
+            }
+            else
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Wox);
+            }
+        }
+
         public const string Wox = "Wox";
         public const string Plugins = "Plugins";
 
         private static readonly Assembly Assembly = Assembly.GetExecutingAssembly();
         public static readonly string ProgramDirectory = Directory.GetParent(Assembly.Location.NonNull()).ToString();
         public static readonly string ExecutablePath = Path.Combine(ProgramDirectory, Wox + ".exe");
-        public static readonly string DataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Wox);
+        public static readonly string DataDirectory = DetermineDataDirectory();
         public static readonly string PluginsDirectory = Path.Combine(DataDirectory, Plugins);
         public static readonly string PreinstalledDirectory = Path.Combine(ProgramDirectory, Plugins);
         public const string Repository = "https://github.com/Wox-launcher/Wox";


### PR DESCRIPTION
Make Wox portable
- Use the VSCode method to enable portable mode (https://code.visualstudio.com/docs/editor/portable)

This change allows creating a UserData directory which will be recognised and used as user's data directory for saved settings and installed plugins.

Work by https://github.com/RaymanNg in PR  https://github.com/Wox-launcher/Wox/pull/2462