### PR TITLE
Add to Sys plugin- save all Wox settings

### DIFF
--- a/Plugins/Wox.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/en.xaml
@@ -5,16 +5,20 @@
     <system:String x:Key="wox_plugin_sys_command">Command</system:String>
     <system:String x:Key="wox_plugin_sys_desc">Description</system:String>
 
+    <system:String x:Key="wox_plugin_sys_save_command">Save Settings</system:String>
+
     <system:String x:Key="wox_plugin_sys_shutdown_computer">Shutdown Computer</system:String>
     <system:String x:Key="wox_plugin_sys_restart_computer">Restart Computer</system:String>
     <system:String x:Key="wox_plugin_sys_log_off">Log off</system:String>
     <system:String x:Key="wox_plugin_sys_lock">Lock this computer</system:String>
     <system:String x:Key="wox_plugin_sys_exit">Close Wox</system:String>
     <system:String x:Key="wox_plugin_sys_restart">Restart Wox</system:String>
+    <system:String x:Key="wox_plugin_sys_save">Save all Wox settings</system:String>
     <system:String x:Key="wox_plugin_sys_setting">Tweak this app</system:String>
     <system:String x:Key="wox_plugin_sys_sleep">Put computer to sleep</system:String>
     <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
 
+    <system:String x:Key="wox_plugin_sys_save_success">Successfully saved all Wox settings</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>
 

--- a/Plugins/Wox.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/en.xaml
@@ -5,20 +5,16 @@
     <system:String x:Key="wox_plugin_sys_command">Command</system:String>
     <system:String x:Key="wox_plugin_sys_desc">Description</system:String>
 
-    <system:String x:Key="wox_plugin_sys_save_command">Save Settings</system:String>
-
     <system:String x:Key="wox_plugin_sys_shutdown_computer">Shutdown Computer</system:String>
     <system:String x:Key="wox_plugin_sys_restart_computer">Restart Computer</system:String>
     <system:String x:Key="wox_plugin_sys_log_off">Log off</system:String>
     <system:String x:Key="wox_plugin_sys_lock">Lock this computer</system:String>
     <system:String x:Key="wox_plugin_sys_exit">Close Wox</system:String>
     <system:String x:Key="wox_plugin_sys_restart">Restart Wox</system:String>
-    <system:String x:Key="wox_plugin_sys_save">Save all Wox settings</system:String>
     <system:String x:Key="wox_plugin_sys_setting">Tweak this app</system:String>
     <system:String x:Key="wox_plugin_sys_sleep">Put computer to sleep</system:String>
     <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
 
-    <system:String x:Key="wox_plugin_sys_save_success">Successfully saved all Wox settings</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>
 

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -169,13 +169,13 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
-                    Title = context.API.GetTranslation("wox_plugin_sys_save_command"),
-                    SubTitle = context.API.GetTranslation("wox_plugin_sys_save"),
+                    Title = "Save Settings",
+                    SubTitle = "Save all Wox settings",
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
                         context.API.SaveAppAllSettings();
-                        context.API.ShowMsg(string.Format(context.API.GetTranslation("wox_plugin_sys_save_success")));
+                        context.API.ShowMsg(string.Format("Successfully saved all Wox settings"));
                         return true;
                     }
                 },

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -169,6 +169,18 @@ namespace Wox.Plugin.Sys
                 },
                 new Result
                 {
+                    Title = context.API.GetTranslation("wox_plugin_sys_save_command"),
+                    SubTitle = context.API.GetTranslation("wox_plugin_sys_save"),
+                    IcoPath = "Images\\app.png",
+                    Action = c =>
+                    {
+                        context.API.SaveAppAllSettings();
+                        context.API.ShowMsg(string.Format(context.API.GetTranslation("wox_plugin_sys_save_success")));
+                        return true;
+                    }
+                },
+                new Result
+                {
                     Title = "Restart Wox",
                     SubTitle = context.API.GetTranslation("wox_plugin_sys_restart"),
                     IcoPath = "Images\\app.png",

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -175,7 +175,7 @@ namespace Wox.Plugin.Sys
                     Action = c =>
                     {
                         context.API.SaveAppAllSettings();
-                        context.API.ShowMsg(string.Format("Successfully saved all Wox settings"));
+                        context.API.ShowMsg("Success","All Wox settings saved");
                         return true;
                     }
                 },

--- a/Wox.Plugin/IPublicAPI.cs
+++ b/Wox.Plugin/IPublicAPI.cs
@@ -58,6 +58,11 @@ namespace Wox.Plugin
         void ShowApp();
 
         /// <summary>
+        /// Save all Wox settings
+        /// </summary>
+        void SaveAppAllSettings();
+
+        /// <summary>
         /// Show message box
         /// </summary>
         /// <param name="title">Message title</param>

--- a/Wox/PublicAPIInstance.cs
+++ b/Wox/PublicAPIInstance.cs
@@ -59,13 +59,18 @@ namespace Wox
             // we must manually save
             // UpdateManager.RestartApp() will call Environment.Exit(0)
             // which will cause ungraceful exit
+            SaveAppAllSettings();
+
+            UpdateManager.RestartApp();
+        }
+
+        public void SaveAppAllSettings()
+        {
             _mainVM.Save();
             _settingsVM.Save();
             PluginManager.Save();
             ImageLoader.Save();
             Alphabet.Save();
-
-            UpdateManager.RestartApp();
         }
 
         [Obsolete]


### PR DESCRIPTION
Open up Save Settings command so users can save all settings without having to wait till program exits.

Helps if an important setting is changed and not wanting to wait till exit. 

https://github.com/jjw24/Wox/issues/20