### PR TITLE
Save all plugins' settings on closing Settings menu

### DIFF
--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -318,6 +318,7 @@ namespace Wox
         private void OnClosed(object sender, EventArgs e)
         {
             _viewModel.Save();
+            PluginManager.Save();
         }
 
         private void OnCloseExecuted(object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
Context:
Wox saves plugins settings on app exit. This is not not too ideal sometimes if app is closed during an exception, error or by taskkill. 

Resolution:
Add save plugins settings when the settings menu is closed so do not have to wait till app to exit in order to save all plugins' settings.