### PR TITLE
Add reindex call to Plugin.Program file suffixes update

### DIFF
--- a/Plugins/Wox.Plugin.Program/ProgramSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.Program/ProgramSetting.xaml.cs
@@ -94,8 +94,11 @@ namespace Wox.Plugin.Program
 
         private void BtnProgramSuffixes_OnClick(object sender, RoutedEventArgs e)
         {
-            ProgramSuffixes p = new ProgramSuffixes(context, _settings);
-            p.ShowDialog();
+            var p = new ProgramSuffixes(context, _settings);
+            if (p.ShowDialog() ?? false)
+            {
+                ReIndexing();
+            }
         }
 
         private void programSourceView_DragEnter(object sender, DragEventArgs e)

--- a/Plugins/Wox.Plugin.Program/ProgramSuffixes.xaml.cs
+++ b/Plugins/Wox.Plugin.Program/ProgramSuffixes.xaml.cs
@@ -30,6 +30,8 @@ namespace Wox.Plugin.Program
             _settings.ProgramSuffixes = tbSuffixes.Text.Split(Settings.SuffixSeperator);
             string msg = context.API.GetTranslation("wox_plugin_program_update_file_suffixes");
             MessageBox.Show(msg);
+
+            DialogResult = true;
         }
     }
 }


### PR DESCRIPTION
When updating file suffixes in the Program plugin, call reindex programs method once user clicks update button so that new files with those suffixes will be updated and displayed in results instead of having to wait till next Wox restart. 

This change will allow users to immediately query for the programs added from updating file suffixes.