### PR TITLE
Include all programs with defined suffixes in Plugins.Programs

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -283,7 +283,11 @@ namespace Wox.Plugin.Program.Programs
             var paths = paths1.Concat(paths2).ToArray();
             var programs1 = paths.AsParallel().Where(p => Extension(p) == ShortcutExtension).Select(LnkProgram);
             var programs2 = paths.AsParallel().Where(p => Extension(p) == ApplicationReferenceExtension).Select(Win32Program);
-            var programs = programs1.Concat(programs2).Where(p => p.Valid);
+            // Include paths from suffixes other than the two extentions above 
+            var programs3 = paths.AsParallel().Where(p => Extension(p) == ShortcutExtension
+                                                        && Extension(p) == ApplicationReferenceExtension)
+                                                .Select(Win32Program);
+            var programs = programs1.Concat(programs2).Concat(programs3).Where(p => p.Valid);
             return programs;
         }
 

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -284,8 +284,8 @@ namespace Wox.Plugin.Program.Programs
             var programs1 = paths.AsParallel().Where(p => Extension(p) == ShortcutExtension).Select(LnkProgram);
             var programs2 = paths.AsParallel().Where(p => Extension(p) == ApplicationReferenceExtension).Select(Win32Program);
             // Include paths from suffixes other than the two extentions above 
-            var programs3 = paths.AsParallel().Where(p => Extension(p) == ShortcutExtension
-                                                        && Extension(p) == ApplicationReferenceExtension)
+            var programs3 = paths.AsParallel().Where(p => Extension(p) != ShortcutExtension
+                                                        && Extension(p) != ApplicationReferenceExtension)
                                                 .Select(Win32Program);
             var programs = programs1.Concat(programs2).Concat(programs3).Where(p => p.Valid);
             return programs;


### PR DESCRIPTION
Issue:
Even though suffixes can be defined in the settings area of the Programs plugin, they are still not included because the code only looks for two extensions rather than whats defined.

Resolution:
Add all others with the defined suffixes other than the two extensions "lnk" and "appref-ms"