### PR TITLE
Fix Result object comparison bug causing Folders plugin to open wrong location

### DIFF
--- a/Wox.Plugin/Result.cs
+++ b/Wox.Plugin/Result.cs
@@ -65,17 +65,13 @@ namespace Wox.Plugin
 
         public override bool Equals(object obj)
         {
-            Result r = obj as Result;
-            if (r != null)
-            {
-                var equality = string.Equals(r.Title, Title) &&
-                               string.Equals(r.SubTitle, SubTitle);
-                return equality;
-            }
-            else
-            {
-                return false;
-            }
+            var r = obj as Result;
+
+            var equality = string.Equals(r?.Title, Title) &&
+                           string.Equals(r?.SubTitle, SubTitle) &&
+                           string.Equals(r?.IcoPath, IcoPath);
+
+            return equality;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
*Problem:*
Using the folder plugin, when navigating to sub-folders and clicking on 'Open Current Directory', the plugin opens to the path set in the folders plugin not the sub-folder user navigated to:

'Open Current Directory'
![image](https://user-images.githubusercontent.com/26427004/64060535-6efb8b00-cc11-11e9-84fe-21ba455a3428.png)

Instead opens the wrong path:
![image](https://user-images.githubusercontent.com/26427004/64060561-ed582d00-cc11-11e9-922c-5d1244b7caba.png)


Cause:
1. In the Result class, the object comparison method only compares title and subtitle, this can be the same for the 'Open Current Directory' all results. The difference in these results however are IcoPath stores different paths.

2. In the ResultsViewModel when the code tries to find same results in result set A and B, it uses Linq's Intersect method. This is a big problem because these equality comparison methods only does an object level comparison, what is needed is actually Wox's own equality comparison method that compares properties in each object. I can see that method already exists in the Result class so I am assuming this is an old piece of code that forgot to be changed to use the Wox's custom method.

Resolution:
1. Added IcoPath property to the comparison method. Also simplified the method's casting and null check by using 'Safe Navigation Operator' '?.'
2. Rewrite the bit that uses Linq's intersect to use the Result class' equality comparison method. Additionally, general polishing of comments and naming for the NewResults method to make it more readable.


Fixes issue https://github.com/jjw24/Wox/issues/27
Fixes issue https://github.com/jjw24/Wox/issues/28