### PR TITLE
Fix ControlPanel plugin search bug

### DIFF
--- a/Plugins/Wox.Plugin.ControlPanel/Main.cs
+++ b/Plugins/Wox.Plugin.ControlPanel/Main.cs
@@ -77,7 +77,7 @@ namespace Wox.Plugin.ControlPanel
         private int Score(ControlPanelItem item, string query)
         {
             var scores = new List<int> {0};
-            if (string.IsNullOrEmpty(item.LocalizedString))
+            if (!string.IsNullOrEmpty(item.LocalizedString))
             {
                 var score1 = StringMatcher.Score(item.LocalizedString, query);
                 var score2 = StringMatcher.ScoreForPinyin(item.LocalizedString, query);


### PR DESCRIPTION
Issue found with ControlPanel plugin where typo causes the code to skip searching control panel item title. This bug is discovered in issue https://github.com/Wox-launcher/Wox/issues/2352. Thanks @thanhmssl10

**Before:**
![image](https://user-images.githubusercontent.com/26427004/65874048-24b02a00-e3c8-11e9-9a32-5a9666d6d10e.png)

**After this fix:**
![image](https://user-images.githubusercontent.com/26427004/65874092-45787f80-e3c8-11e9-9df0-fef38f7343b2.png)

 