### PR TITLE
Fix Firefox bookmarks not showing

### DIFF
--- a/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
@@ -27,20 +27,25 @@ namespace Wox.Plugin.BrowserBookmark
             if (string.IsNullOrEmpty(PlacesPath) || !File.Exists(PlacesPath))
                 return new List<Bookmark>();
 
+            var bookmarList = new List<Bookmark>();
+
             // create the connection string and init the connection
-            string dbPath = string.Format(dbPathFormat, PlacesPath);
-            var dbConnection = new SQLiteConnection(dbPath);
-
-            // Open connection to the database file and execute the query
-            dbConnection.Open();
-            var reader = new SQLiteCommand(queryAllBookmarks, dbConnection).ExecuteReader();
-
-            // return results in List<Bookmark> format
-            return reader.Select(x => new Bookmark()
+            string dbPath = string.Format(dbPathFormat, PlacesPath);            
+            using (var dbConnection = new SQLiteConnection(dbPath))
             {
-                Name = (x["title"] is DBNull) ? string.Empty : x["title"].ToString(),
-                Url = x["url"].ToString()
-            }).ToList();
+                // Open connection to the database file and execute the query
+                dbConnection.Open();
+                var reader = new SQLiteCommand(queryAllBookmarks, dbConnection).ExecuteReader();
+
+                // return results in List<Bookmark> format
+                bookmarList = reader.Select(x => new Bookmark()
+                {
+                    Name = (x["title"] is DBNull) ? string.Empty : x["title"].ToString(),
+                    Url = x["url"].ToString()
+                }).ToList();
+            }
+
+            return bookmarList;
         }
 
         /// <summary>

--- a/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/FirefoxBookmarks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.IO;
@@ -61,17 +61,52 @@ namespace Wox.Plugin.BrowserBookmark
                 using (var sReader = new StreamReader(profileIni)) {
                     ini = sReader.ReadToEnd();
                 }
+
+                /*
+                    Current profiles.ini structure example as of Firefox version 69.0.1
+                    
+                    [Install736426B0AF4A39CB]
+                    Default=Profiles/7789f565.default-release   <== this is the default profile this plugin will get the bookmarks from. When opened Firefox will load the default profile
+                    Locked=1
+
+                    [Profile2]
+                    Name=newblahprofile
+                    IsRelative=0
+                    Path=C:\t6h2yuq8.newblahprofile  <== Note this is a custom location path for the profile user can set, we need to cater for this in code.
+
+                    [Profile1]
+                    Name=default
+                    IsRelative=1
+                    Path=Profiles/cydum7q4.default
+                    Default=1
+
+                    [Profile0]
+                    Name=default-release
+                    IsRelative=1
+                    Path=Profiles/7789f565.default-release
+
+                    [General]
+                    StartWithLastProfile=1
+                    Version=2
+                */
+
                 var lines = ini.Split(new string[] { "\r\n" }, StringSplitOptions.None).ToList();
 
-                var index = lines.IndexOf("Default=1");
-                if (index > 3) {
-                    var relative = lines[index - 2].Split('=')[1];
-                    var profiePath = lines[index - 1].Split('=')[1];
-                    return relative == "0"
-                        ? profiePath + @"\places.sqlite"
-                        : Path.Combine(profileFolderPath, profiePath) + @"\places.sqlite";
-                }
-                return string.Empty;
+                var defaultProfileFolderNameRaw = lines.Where(x => x.Contains("Default=") && x != "Default=1").FirstOrDefault() ?? string.Empty;
+
+                if (string.IsNullOrEmpty(defaultProfileFolderNameRaw))
+                    return string.Empty;
+
+                var defaultProfileFolderName = defaultProfileFolderNameRaw.Split('=').Last();
+
+                var indexOfDefaultProfileAtttributePath = lines.IndexOf("Path="+ defaultProfileFolderName);
+
+                // Seen in the example above, the IsRelative attribute is always above the Path attribute
+                var relativeAttribute = lines[indexOfDefaultProfileAtttributePath - 1];
+
+                return relativeAttribute == "0" // See above, the profile is located in a custom location, path is not relative, so IsRelative=0
+                        ? defaultProfileFolderName + @"\places.sqlite"
+                        : Path.Combine(profileFolderPath, defaultProfileFolderName) + @"\places.sqlite";
             }
         }
     }

--- a/Plugins/Wox.Plugin.BrowserBookmark/Wox.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Wox.Plugin.BrowserBookmark.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,6 +14,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,14 +37,26 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.93.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.93.0\lib\net20\System.Data.SQLite.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net451\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net451\System.Data.SQLite.EF6.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net451\System.Data.SQLite.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="UnidecodeSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\UnidecodeSharp.1.0.0.0\lib\net35\UnidecodeSharp.dll</HintPath>
       <Private>True</Private>
@@ -86,6 +100,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets" Condition="Exists('..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\System.Data.SQLite.Core.1.0.111.0\build\net451\System.Data.SQLite.Core.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Plugins/Wox.Plugin.BrowserBookmark/app.config
+++ b/Plugins/Wox.Plugin.BrowserBookmark/app.config
@@ -1,4 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  
-<system.data><DbProviderFactories><remove invariant="System.Data.SQLite"/><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite"/></DbProviderFactories></system.data><startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+    </providers>
+  </entityFramework>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+  </system.data>
+</configuration>

--- a/Plugins/Wox.Plugin.BrowserBookmark/packages.config
+++ b/Plugins/Wox.Plugin.BrowserBookmark/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Data.SQLite" version="1.0.93.0" targetFramework="net35" />
-  <package id="System.Data.SQLite.Core" version="1.0.93.0" targetFramework="net35" requireReinstallation="true" />
-  <package id="System.Data.SQLite.Linq" version="1.0.93.0" targetFramework="net35" requireReinstallation="true" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
+  <package id="System.Data.SQLite" version="1.0.111.0" targetFramework="net452" />
+  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net452" />
+  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net452" />
+  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net452" />
   <package id="UnidecodeSharp" version="1.0.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Problem Context:
Firefox bookmarks not showing by the BrowserBookmarks plugin.

Reason:
Code is looking for "Default=1" attribute in Profile.ini to determine the path to the bookmarks. However this attribute according to Mozillazine knowledgebase (http://kb.mozillazine.org/Profiles.ini_file) is used to indicate the last selected profile, which has not been the case since the recent Firefox release. Using "Default=Profile/X...x" is a better way of determining the default profile used and then the location of the bookmarks in that profile.

https://github.com/jjw24/Wox/issues/44

Reported issue: 
https://github.com/Wox-launcher/Wox.Plugin.BrowserBookmark/issues/18
https://github.com/Wox-launcher/Wox.Plugin.BrowserBookmark/issues/10

Fixes:
- Updated logic to look for attribute "Default=Profile/X"
- Replace dbConnection.Open with Using. The code didn't not close the sqlconnection, which is not ideal.

Tested on Firefox v69.0.1