### PR TITLE
Fix WebSearch plugin missing query part when searching with global wildcard

### DIFF
--- a/Plugins/Wox.Plugin.WebSearch/Main.cs
+++ b/Plugins/Wox.Plugin.WebSearch/Main.cs
@@ -49,10 +49,11 @@ namespace Wox.Plugin.WebSearch
             {
                 foreach (SearchSource searchSource in searchSourceList)
                 {
-                    string keyword = query.Search;
-                    string title = keyword;
-                    string subtitle = _context.API.GetTranslation("wox_plugin_websearch_search") + " " +
-                                      searchSource.Title;
+                    string keyword = string.Empty;
+                    keyword = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? query.ToString() : query.Search;
+                    var title = keyword;
+                    string subtitle = _context.API.GetTranslation("wox_plugin_websearch_search") + " " + searchSource.Title;
+
                     if (string.IsNullOrEmpty(keyword))
                     {
                         var result = new Result


### PR DESCRIPTION
Fix when using the WebSearch plugin, part of query will be missing due to being the same as local action keyword.