### PR TITLE
Enable manual plugin data reload

### DIFF
--- a/Plugins/Wox.Plugin.BrowserBookmark/Commands/Bookmarks.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Commands/Bookmarks.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Wox.Infrastructure;
+
+namespace Wox.Plugin.BrowserBookmark.Commands
+{
+    internal static class Bookmarks
+    {
+        internal static bool MatchProgram(Bookmark bookmark, string queryString)
+        {
+            if (StringMatcher.FuzzySearch(queryString, bookmark.Name, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
+            if (StringMatcher.FuzzySearch(queryString, bookmark.PinyinName, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
+            if (StringMatcher.FuzzySearch(queryString, bookmark.Url, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
+
+            return false;
+        }
+
+        internal static List<Bookmark> LoadAllBookmarks()
+        {
+            var allbookmarks = new List<Bookmark>();
+            
+            var chromeBookmarks = new ChromeBookmarks();
+            var mozBookmarks = new FirefoxBookmarks();
+
+            //TODO: Let the user select which browser's bookmarks are displayed
+            // Add Firefox bookmarks
+            mozBookmarks.GetBookmarks().ForEach(x => allbookmarks.Add(x));
+
+            // Add Chrome bookmarks
+            chromeBookmarks.GetBookmarks().ForEach(x => allbookmarks.Add(x));
+
+            return allbookmarks.Distinct().ToList();
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Wox.Infrastructure;
+using Wox.Plugin.BrowserBookmark.Commands;
 using Wox.Plugin.SharedCommands;
 
 namespace Wox.Plugin.BrowserBookmark
@@ -8,25 +8,14 @@ namespace Wox.Plugin.BrowserBookmark
     public class Main : IPlugin
     {
         private PluginInitContext context;
-
-        // TODO: periodically refresh the Cache?
+        
         private List<Bookmark> cachedBookmarks = new List<Bookmark>(); 
 
         public void Init(PluginInitContext context)
         {
             this.context = context;
 
-            // Cache all bookmarks
-            var chromeBookmarks = new ChromeBookmarks();
-            var mozBookmarks = new FirefoxBookmarks();
-
-            //TODO: Let the user select which browser's bookmarks are displayed
-            // Add Firefox bookmarks
-            cachedBookmarks.AddRange(mozBookmarks.GetBookmarks());
-            // Add Chrome bookmarks
-            cachedBookmarks.AddRange(chromeBookmarks.GetBookmarks());
-
-            cachedBookmarks = cachedBookmarks.Distinct().ToList();
+            cachedBookmarks = Bookmarks.LoadAllBookmarks();
         }
 
         public List<Result> Query(Query query)
@@ -41,7 +30,7 @@ namespace Wox.Plugin.BrowserBookmark
             if (!topResults)
             {
                 // Since we mixed chrome and firefox bookmarks, we should order them again                
-                returnList = cachedBookmarks.Where(o => MatchProgram(o, param)).ToList();
+                returnList = cachedBookmarks.Where(o => Bookmarks.MatchProgram(o, param)).ToList();
                 returnList = returnList.OrderByDescending(o => o.Score).ToList();
             }
             
@@ -58,15 +47,6 @@ namespace Wox.Plugin.BrowserBookmark
                     return true;
                 }
             }).ToList();
-        }
-
-        private bool MatchProgram(Bookmark bookmark, string queryString)
-        {
-            if (StringMatcher.FuzzySearch(queryString, bookmark.Name, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
-            if ( StringMatcher.FuzzySearch(queryString, bookmark.PinyinName, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
-            if (StringMatcher.FuzzySearch(queryString, bookmark.Url, new MatchOption()).IsSearchPrecisionScoreMet()) return true;
-
-            return false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
@@ -5,7 +5,7 @@ using Wox.Plugin.SharedCommands;
 
 namespace Wox.Plugin.BrowserBookmark
 {
-    public class Main : IPlugin
+    public class Main : IPlugin, IReloadable
     {
         private PluginInitContext context;
         
@@ -47,6 +47,13 @@ namespace Wox.Plugin.BrowserBookmark
                     return true;
                 }
             }).ToList();
+        }
+
+        public void ReloadData()
+        {
+            cachedBookmarks.Clear();
+
+            cachedBookmarks = Bookmarks.LoadAllBookmarks();
         }
     }
 }

--- a/Plugins/Wox.Plugin.BrowserBookmark/Wox.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Wox.Plugin.BrowserBookmark.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="Bookmark.cs" />
     <Compile Include="ChromeBookmarks.cs" />
+    <Compile Include="Commands\Bookmarks.cs" />
     <Compile Include="FirefoxBookmarks.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Plugins/Wox.Plugin.Program/Main.cs
+++ b/Plugins/Wox.Plugin.Program/Main.cs
@@ -13,7 +13,7 @@ using Stopwatch = Wox.Infrastructure.Stopwatch;
 
 namespace Wox.Plugin.Program
 {
-    public class Main : ISettingProvider, IPlugin, IPluginI18n, IContextMenu, ISavable
+    public class Main : ISettingProvider, IPlugin, IPluginI18n, IContextMenu, ISavable, IReloadable
     {
         private static readonly object IndexLock = new object();
         private static Win32[] _win32s;
@@ -144,6 +144,14 @@ namespace Wox.Plugin.Program
                 hide = false;
             }
             return hide;
+        }
+
+        public void ReloadData()
+        {
+            Task.Run(() =>
+            {
+               IndexPrograms();
+            });
         }
     }
 }

--- a/Plugins/Wox.Plugin.Program/Main.cs
+++ b/Plugins/Wox.Plugin.Program/Main.cs
@@ -148,10 +148,7 @@ namespace Wox.Plugin.Program
 
         public void ReloadData()
         {
-            Task.Run(() =>
-            {
-               IndexPrograms();
-            });
+            IndexPrograms();
         }
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Sys/Languages/en.xaml
@@ -15,6 +15,10 @@
     <system:String x:Key="wox_plugin_sys_sleep">Put computer to sleep</system:String>
     <system:String x:Key="wox_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
 
+    <!--Dialogs-->
+    <system:String x:Key="wox_plugin_sys_dlgtitle_success">Success</system:String>
+    <system:String x:Key="wox_plugin_sys_dlgtext_all_applicableplugins_reloaded">Reloaded all applicable plugin data</system:String>
+
     <system:String x:Key="wox_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="wox_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>
 

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -207,6 +207,17 @@ namespace Wox.Plugin.Sys
                         context.API.OpenSettingDialog();
                         return true;
                     }
+                },
+                new Result
+                {
+                    Title = "Reload Plugin Data",
+                    SubTitle = "Reloads plugin's data with new content added after Wox started. Plugins need to have this feature already added.",
+                    IcoPath = "Images\\app.png",
+                    Action = c =>
+                    {
+                        context.API.ReloadPluginData();
+                        return true;
+                    }
                 }
             });
             return results;

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -215,7 +215,7 @@ namespace Wox.Plugin.Sys
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
-                        context.API.ReloadPluginData();
+                        context.API.ReloadAllPluginData();
                         return true;
                     }
                 }

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -211,7 +211,7 @@ namespace Wox.Plugin.Sys
                 new Result
                 {
                     Title = "Reload Plugin Data",
-                    SubTitle = "Reloads plugin's data with new content added after Wox started. Plugins need to have this feature already added.",
+                    SubTitle = "Reloads plugin data with new content added after Wox started. Plugins need to have this feature already added.",
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -215,7 +215,11 @@ namespace Wox.Plugin.Sys
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
+                        // Hide the window first then show msg after done because sometimes the reload could take a while, so not to make user think it's frozen. 
+                        Application.Current.MainWindow.Hide();
                         context.API.ReloadAllPluginData();
+                        context.API.ShowMsg(context.API.GetTranslation("wox_plugin_sys_dlgtitle_success"),
+                            context.API.GetTranslation("wox_plugin_sys_dlgtext_all_applicableplugins_reloaded"));
                         return true;
                     }
                 }

--- a/Wox.Core/Plugin/PluginManager.cs
+++ b/Wox.Core/Plugin/PluginManager.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Wox.Core.Resource;
 using Wox.Infrastructure;
-using Wox.Infrastructure.Exception;
 using Wox.Infrastructure.Logger;
 using Wox.Infrastructure.Storage;
 using Wox.Infrastructure.UserSettings;
@@ -63,6 +61,15 @@ namespace Wox.Core.Plugin
             {
                 var savable = plugin.Plugin as ISavable;
                 savable?.Save();
+            }
+        }
+
+        public static void ReloadData()
+        {
+            foreach(var plugin in AllPlugins)
+            {
+                var reloadablePlugin = plugin.Plugin as IReloadable;
+                reloadablePlugin?.ReloadData();
             }
         }
 

--- a/Wox.Plugin/IPublicAPI.cs
+++ b/Wox.Plugin/IPublicAPI.cs
@@ -63,6 +63,14 @@ namespace Wox.Plugin
         void SaveAppAllSettings();
 
         /// <summary>
+        /// Reloads any Plugins that have the 
+        /// IReloadable implemented. It refeshes
+        /// Plugin's in memory data with new content
+        /// added by user.
+        /// </summary>
+        void ReloadPluginData();
+
+        /// <summary>
         /// Show message box
         /// </summary>
         /// <param name="title">Message title</param>

--- a/Wox.Plugin/IPublicAPI.cs
+++ b/Wox.Plugin/IPublicAPI.cs
@@ -68,7 +68,7 @@ namespace Wox.Plugin
         /// Plugin's in memory data with new content
         /// added by user.
         /// </summary>
-        void ReloadPluginData();
+        void ReloadAllPluginData();
 
         /// <summary>
         /// Show message box

--- a/Wox.Plugin/Interfaces/IReloadable.cs
+++ b/Wox.Plugin/Interfaces/IReloadable.cs
@@ -1,0 +1,18 @@
+﻿namespace Wox.Plugin
+{
+    /// <summary>
+    /// This interface is to indicate and allow plugins to reload their
+    /// in memory data cache or other mediums when user makes a new change
+    /// that is not immediately captured. For example, for BrowserBookmark and Program
+    /// plugin does not automatically detect when a user added a new bookmark or program,
+    /// so this interface's function is exposed to allow user manually do the reloading after 
+    /// those new additions.
+    /// 
+    /// The command that allows user to manual reload is exposed via Plugin.Sys, and
+    /// it will call the plugins that have implemented this interface.
+    /// </summary>
+    public interface IReloadable
+    {
+        void ReloadData();
+    }
+}

--- a/Wox.Plugin/Wox.Plugin.csproj
+++ b/Wox.Plugin/Wox.Plugin.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Features\IContextMenu.cs" />
     <Compile Include="Features\IExclusiveQuery.cs" />
     <Compile Include="Features\IInstantQuery.cs" />
+    <Compile Include="Interfaces\IReloadable.cs" />
     <Compile Include="IPlugin.cs" />
     <Compile Include="IPublicAPI.cs" />
     <Compile Include="ISettingProvider.cs" />

--- a/Wox/PublicAPIInstance.cs
+++ b/Wox/PublicAPIInstance.cs
@@ -73,6 +73,11 @@ namespace Wox
             Alphabet.Save();
         }
 
+        public void ReloadAllPluginData()
+        {
+            PluginManager.ReloadData();
+        }
+
         [Obsolete]
         public void HideApp()
         {


### PR DESCRIPTION
For Plugins such as Program and BrowserBookmarks or any plugin that would persist data in memory, will not have new content refreshed until next Wox restart.

This means users installed a new program, added a new bookmark etc, will not be able to see these new content until they restart Wox.

This feature is:
1. Providing a command for user to manual reload all plugin's data (provided the plugin has implemented this feature) via Plugin.Sys
2. Allowing plugins to implement IReloadable and define their own way of reloading in memory data that will be called when user use the command above.
3. Added into BrowserBookmarks and Programs plugins.

Requested in: 
https://github.com/Wox-launcher/Wox.Plugin.BrowserBookmark/issues/16
https://github.com/Wox-launcher/Wox.Plugin.BrowserBookmark/issues/15