### PR TITLE
Remove BrowserBookmark subtitle wording "Boomark"

### DIFF
--- a/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Wox.Plugin.BrowserBookmark/Main.cs
@@ -48,7 +48,7 @@ namespace Wox.Plugin.BrowserBookmark
             return returnList.Select(c => new Result()
             {
                 Title = c.Name,
-                SubTitle = "Bookmark: " + c.Url,
+                SubTitle = c.Url,
                 IcoPath = @"Images\bookmark.png",
                 Score = 5,
                 Action = (e) =>


### PR DESCRIPTION
Remove BrowserBookmark subtitle wording "Boomark" which is displayed for every bookmark- not necessary.