### PR TITLE
Fix plugin start up disabled by default + disabling Everything & HelloWorldCSharp plugins

### DIFF
--- a/Plugins/HelloWorldCSharp/plugin.json
+++ b/Plugins/HelloWorldCSharp/plugin.json
@@ -8,5 +8,6 @@
     "Language":"csharp",
     "Website":"https://github.com/Wox-launcher/Wox",
     "ExecuteFileName":"HelloWorldCSharp.dll",
-    "IcoPath":"app.png"
+    "IcoPath":"app.png",
+    "Disabled": true
 }

--- a/Plugins/Wox.Plugin.Everything/plugin.json
+++ b/Plugins/Wox.Plugin.Everything/plugin.json
@@ -8,5 +8,6 @@
     "Language":"csharp",
     "Website":"http://www.wox.one",
     "IcoPath":"Images\\find.png",
-    "ExecuteFileName":"Wox.Plugin.Everything.dll"
+    "ExecuteFileName":"Wox.Plugin.Everything.dll",
+    "Disabled": true
 }

--- a/Wox.Infrastructure/UserSettings/PluginSettings.cs
+++ b/Wox.Infrastructure/UserSettings/PluginSettings.cs
@@ -29,7 +29,7 @@ namespace Wox.Infrastructure.UserSettings
                         ID = metadata.ID,
                         Name = metadata.Name,
                         ActionKeywords = metadata.ActionKeywords,
-                        Disabled = false
+                        Disabled = metadata.Disabled
                     };
                 }
             }


### PR DESCRIPTION
This fix allows some local plugins to start up as disabled by default.

Local plugins might not be used at all so do not need to have them enabled to clog up space, ie Everything & HelloWorldCSharp plugins.

Currently this fork is not maintaining the integration of Everything plugin, although it is great tool for some users, personally find it not necessary as of yet and the application that the plugin actually requires is a bit of a memory hog. Users can re-enable if they like to use it after downloading this Wox.

HelloWorldCSharp plugin's direction is unclear, and is there as a skeleton/guide perhaps for future developers to build C# plugins, but not necessary for the everyday user.