### PR TITLE
Set HideWhenDeactive default as true

### DIFF
--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -66,7 +66,7 @@ namespace Wox.Infrastructure.UserSettings
             }
         }
         public bool LeaveCmdOpen { get; set; }
-        public bool HideWhenDeactive { get; set; }
+        public bool HideWhenDeactive { get; set; } = true;
         public bool RememberLastLaunchLocation { get; set; }
         public bool IgnoreHotkeysOnFullscreen { get; set; }
 


### PR DESCRIPTION
Setting default behaviour of hiding Wox query window as true.