### PR TITLE
Add return to main query window from context menu after selection

### DIFF
--- a/Wox/ViewModel/MainViewModel.cs
+++ b/Wox/ViewModel/MainViewModel.cs
@@ -96,7 +96,7 @@ namespace Wox.ViewModel
         {
             EscCommand = new RelayCommand(_ =>
             {
-                if (!ResultsSelected())
+                if (!SelectedIsFromQueryResults())
                 {
                     SelectedResults = Results;
                 }
@@ -153,17 +153,21 @@ namespace Wox.ViewModel
                         MainWindowVisibility = Visibility.Collapsed;
                     }
 
-                    if (ResultsSelected())
+                    if (SelectedIsFromQueryResults())
                     {
                         _userSelectedRecord.Add(result);
                         _history.Add(result.OriginQuery.RawQuery);
+                    }
+                    else
+                    {
+                        SelectedResults = Results;
                     }
                 }
             });
 
             LoadContextMenuCommand = new RelayCommand(_ =>
             {
-                if (ResultsSelected())
+                if (SelectedIsFromQueryResults())
                 {
                     SelectedResults = ContextMenu;
                 }
@@ -175,7 +179,7 @@ namespace Wox.ViewModel
 
             LoadHistoryCommand = new RelayCommand(_ =>
             {
-                if (ResultsSelected())
+                if (SelectedIsFromQueryResults())
                 {
                     SelectedResults = History;
                     History.SelectedIndex = _history.Items.Count - 1;
@@ -226,7 +230,7 @@ namespace Wox.ViewModel
             set
             {
                 _selectedResults = value;
-                if (ResultsSelected())
+                if (SelectedIsFromQueryResults())
                 {
                     ContextMenu.Visbility = Visibility.Collapsed;
                     History.Visbility = Visibility.Collapsed;
@@ -273,7 +277,7 @@ namespace Wox.ViewModel
 
         public void Query()
         {
-            if (ResultsSelected())
+            if (SelectedIsFromQueryResults())
             {
                 QueryResults();
             }
@@ -487,7 +491,7 @@ namespace Wox.ViewModel
             return menu;
         }
 
-        private bool ResultsSelected()
+        private bool SelectedIsFromQueryResults()
         {
             var selected = SelectedResults == Results;
             return selected;


### PR DESCRIPTION
Return back to query window after clicking on a selection in the context menu