### PR TITLE
Add known errors during debug run

### DIFF
--- a/Plugins/Wox.Plugin.Program/Logger/ProgramLogger.cs
+++ b/Plugins/Wox.Plugin.Program/Logger/ProgramLogger.cs
@@ -110,7 +110,7 @@ namespace Wox.Plugin.Program.Logger
         private static bool IsKnownUWPProgramError(Exception e, string callingMethodName)
         {
             if (((e.HResult == -2147024774 || e.HResult == -2147009769) && callingMethodName == "ResourceFromPri")
-                || (e.HResult == -2147024894 && callingMethodName == "LogoPathFromUri"))
+                || (e.HResult == -2147024894 && (callingMethodName == "LogoPathFromUri" || callingMethodName == "ImageFromPath")))
                 return true;
 
             if (callingMethodName == "XmlNamespaces")

--- a/Plugins/Wox.Plugin.Program/Logger/ProgramLogger.cs
+++ b/Plugins/Wox.Plugin.Program/Logger/ProgramLogger.cs
@@ -110,7 +110,8 @@ namespace Wox.Plugin.Program.Logger
         private static bool IsKnownUWPProgramError(Exception e, string callingMethodName)
         {
             if (((e.HResult == -2147024774 || e.HResult == -2147009769) && callingMethodName == "ResourceFromPri")
-                || (e.HResult == -2147024894 && (callingMethodName == "LogoPathFromUri" || callingMethodName == "ImageFromPath")))
+                || (e.HResult == -2147024894 && (callingMethodName == "LogoPathFromUri" || callingMethodName == "ImageFromPath"))
+                || (e.HResult == -2147024864 && callingMethodName == "InitializeAppInfo"))
                 return true;
 
             if (callingMethodName == "XmlNamespaces")

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -86,6 +86,8 @@ namespace Wox.Plugin.Program.Programs
                 var e = Marshal.GetExceptionForHR((int)hResult);
                 ProgramLogger.LogException($"|UWP|InitializeAppInfo|{path}" +
                                                 "|Error caused while trying to get the details of the UWP program", e);
+
+                Apps = new List<Application>().ToArray();
             }
         }
 


### PR DESCRIPTION
Add a known error when trying to load image for UWP program. 
Add a known error when uwp namespace xml is being held by another process.

These should allow program to continue any way but logged it as 'Known' in the error log