### PR TITLE
Uwperrorfix

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -196,11 +196,20 @@ namespace Wox.Plugin.Program.Programs
                 ps = ps.Where(p =>
                 {
                     bool valid;
+                    try
+                    {
+                        var f = p.IsFramework;
+                        var d = p.IsDevelopmentMode;
+                        var path = p.InstalledLocation.Path;
+                        valid = !f && !d && !string.IsNullOrEmpty(path);
+                    }
+                    catch (Exception e)
+                    {
+                        ProgramLogger.LogException("|UWP|CurrentUserPackages|An unexpected error occured and "
+                                                   + $"unable to verify if package is valid", e);
+                        return false;
+                    }
                     
-                    var f = p.IsFramework;
-                    var d = p.IsDevelopmentMode;
-                    var path = p.InstalledLocation.Path;
-                    valid = !f && !d && !string.IsNullOrEmpty(path);
                     
                     return valid;
                 });


### PR DESCRIPTION
in UWP when creating the plugin, durring the UWP.All, when getting the current user packages I got an unhandled exception from:
var path = p.InstalledLocation.Path;
resulting in not loading the plugin.