### PR TITLE
Highlight how results matched

### DIFF
--- a/Plugins/Wox.Plugin.Everything/Main.cs
+++ b/Plugins/Wox.Plugin.Everything/Main.cs
@@ -55,6 +55,7 @@ namespace Wox.Plugin.Everything
                         r.Title = Path.GetFileName(path);
                         r.SubTitle = path;
                         r.IcoPath = path;
+                        r.TitleHighlightData = StringMatcher.FuzzySearch(keyword, Path.GetFileName(path)).MatchData;
                         r.Action = c =>
                         {
                             bool hide;
@@ -78,6 +79,7 @@ namespace Wox.Plugin.Everything
                             return hide;
                         };
                         r.ContextData = s;
+                        r.SubTitleHighlightData = StringMatcher.FuzzySearch(keyword, path).MatchData;
                         results.Add(r);
                     }
                 }

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using Wox.Infrastructure;
 using Wox.Infrastructure.Storage;
 
 namespace Wox.Plugin.Folder
@@ -53,6 +54,7 @@ namespace Wox.Plugin.Folder
                         Title = item.Nickname,
                         IcoPath = item.Path,
                         SubTitle = "Ctrl + Enter to open the directory",
+                        TitleHighlightData = StringMatcher.FuzzySearch(item.Nickname, search).MatchData,
                         Action = c =>
                         {
                             if (c.SpecialKeyState.CtrlPressed)
@@ -148,6 +150,8 @@ namespace Wox.Plugin.Folder
                 }
             });
 
+            string searchNickname = new FolderLink { Path = query.Search }.Nickname;
+
             //Add children directories
             DirectoryInfo[] dirs = new DirectoryInfo(search).GetDirectories();
             foreach (DirectoryInfo dir in dirs)
@@ -162,6 +166,7 @@ namespace Wox.Plugin.Folder
                     Title = dir.Name,
                     IcoPath = dir.FullName,
                     SubTitle = "Ctrl + Enter to open the directory",
+                    TitleHighlightData = StringMatcher.FuzzySearch(dir.Name, searchNickname).MatchData,
                     Action = c =>
                     {
                         if (c.SpecialKeyState.CtrlPressed)
@@ -197,6 +202,7 @@ namespace Wox.Plugin.Folder
                 {
                     Title = Path.GetFileName(filePath),
                     IcoPath = filePath,
+                    TitleHighlightData = StringMatcher.FuzzySearch(file.Name, searchNickname).MatchData,
                     Action = c =>
                     {
                         try

--- a/Plugins/Wox.Plugin.PluginManagement/Main.cs
+++ b/Plugins/Wox.Plugin.PluginManagement/Main.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Newtonsoft.Json;
+using Wox.Infrastructure;
 using Wox.Infrastructure.Http;
 using Wox.Infrastructure.Logger;
 
@@ -142,6 +143,8 @@ namespace Wox.Plugin.PluginManagement
                     Title = r.name,
                     SubTitle = r.description,
                     IcoPath = "Images\\plugin.png",
+                    TitleHighlightData = StringMatcher.FuzzySearch(query.SecondSearch, r.name).MatchData,
+                    SubTitleHighlightData = StringMatcher.FuzzySearch(query.SecondSearch, r.description).MatchData,
                     Action = c =>
                     {
                         MessageBoxResult result = MessageBox.Show("Are you sure you wish to install the \'" + r.name + "\' plugin",
@@ -191,6 +194,8 @@ namespace Wox.Plugin.PluginManagement
                     Title = plugin.Name,
                     SubTitle = plugin.Description,
                     IcoPath = plugin.IcoPath,
+                    TitleHighlightData = StringMatcher.FuzzySearch(query.SecondSearch, plugin.Name).MatchData,
+                    SubTitleHighlightData = StringMatcher.FuzzySearch(query.SecondSearch, plugin.Description).MatchData,
                     Action = e =>
                     {
                         UnInstallPlugin(plugin);

--- a/Plugins/Wox.Plugin.Program/Main.cs
+++ b/Plugins/Wox.Plugin.Program/Main.cs
@@ -111,9 +111,9 @@ namespace Wox.Plugin.Program
 
         public static void IndexPrograms()
         {
-            var t1 = Task.Run(IndexWin32Programs);
+            var t1 = Task.Run(()=>IndexWin32Programs());
 
-            var t2 = Task.Run(IndexUWPPrograms);
+            var t2 = Task.Run(()=>IndexUWPPrograms());
 
             Task.WaitAll(t1, t2);
 

--- a/Plugins/Wox.Plugin.Program/Main.cs
+++ b/Plugins/Wox.Plugin.Program/Main.cs
@@ -78,8 +78,8 @@ namespace Wox.Plugin.Program
             }
 
             var results1 = win32.AsParallel()
-                    .Where(p => p.Enabled)
-                    .Select(p => p.Result(query.Search, _context.API));
+                .Where(p => p.Enabled)
+                .Select(p => p.Result(query.Search, _context.API));
 
             var results2 = uwps.AsParallel()
                 .Where(p => p.Enabled)

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -300,8 +300,9 @@ namespace Wox.Plugin.Program.Programs
                 }
                 else if (!string.IsNullOrEmpty(Description))
                 {
-                    result.Title = $"{DisplayName}: {Description}";
-                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, DisplayName).MatchData;
+                    var title = $"{DisplayName}: {Description}";
+                    result.Title = title;
+                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, title).MatchData;
                 }
                 else
                 {

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -35,7 +35,6 @@ namespace Wox.Plugin.Program.Programs
 
         public UWP(Package package)
         {
-
             Location = package.InstalledLocation.Path;
             Name = package.Id.Name;
             FullName = package.Id.FullName;
@@ -266,11 +265,9 @@ namespace Wox.Plugin.Program.Programs
 
             private int Score(string query)
             {
-                var score1 = StringMatcher.FuzzySearch(query, DisplayName).ScoreAfterSearchPrecisionFilter();
-                var score2 = StringMatcher.ScoreForPinyin(DisplayName, query);
-                var score3 = StringMatcher.FuzzySearch(query, Description).ScoreAfterSearchPrecisionFilter();
-                var score4 = StringMatcher.ScoreForPinyin(Description, query);
-                var score = new[] { score1, score2, score3, score4 }.Max();
+                var displayNameMatch = StringMatcher.FuzzySearch(query, DisplayName);
+                var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
+                var score = new[] { displayNameMatch.Score, descriptionMatch.Score }.Max();
                 return score;
             }
 
@@ -293,14 +290,17 @@ namespace Wox.Plugin.Program.Programs
                     Description.Substring(0, DisplayName.Length) == DisplayName)
                 {
                     result.Title = Description;
+                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
                 }
                 else if (!string.IsNullOrEmpty(Description))
                 {
                     result.Title = $"{DisplayName}: {Description}";
+                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, DisplayName).MatchData;
                 }
                 else
                 {
                     result.Title = DisplayName;
+                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, DisplayName).MatchData;
                 }
                 return result;
             }

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -69,8 +69,9 @@ namespace Wox.Plugin.Program.Programs
             }
             else if (!string.IsNullOrEmpty(Description))
             {
-                result.Title = $"{Name}: {Description}";
-                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
+                var title = $"{Name}: {Description}";
+                result.Title = title;
+                result.TitleHighlightData = StringMatcher.FuzzySearch(query, title).MatchData;
             }
             else
             {

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -33,12 +33,10 @@ namespace Wox.Plugin.Program.Programs
 
         private int Score(string query)
         {
-            var score1 = StringMatcher.FuzzySearch(query, Name).ScoreAfterSearchPrecisionFilter();
-            var score2 = StringMatcher.ScoreForPinyin(Name, query);
-            var score3 = StringMatcher.FuzzySearch(query, Description).ScoreAfterSearchPrecisionFilter();
-            var score4 = StringMatcher.ScoreForPinyin(Description, query);
-            var score5 = StringMatcher.FuzzySearch(query, ExecutableName).ScoreAfterSearchPrecisionFilter();
-            var score = new[] { score1, score2, score3, score4, score5 }.Max();
+            var nameMatch = StringMatcher.FuzzySearch(query, Name);
+            var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
+            var executableNameMatch = StringMatcher.FuzzySearch(query, ExecutableName);
+            var score = new[] { nameMatch.Score, descriptionMatch.Score, executableNameMatch.Score }.Max();
             return score;
         }
 
@@ -67,14 +65,17 @@ namespace Wox.Plugin.Program.Programs
                 Description.Substring(0, Name.Length) == Name)
             {
                 result.Title = Description;
+                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
             }
             else if (!string.IsNullOrEmpty(Description))
             {
                 result.Title = $"{Name}: {Description}";
+                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
             }
             else
             {
                 result.Title = Name;
+                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Name).MatchData;
             }
 
             return result;

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -56,12 +56,21 @@ namespace Wox.Plugin.Sys
             var results = new List<Result>();
             foreach (var c in commands)
             {
-                var titleScore = StringMatcher.FuzzySearch(query.Search, c.Title).ScoreAfterSearchPrecisionFilter();
-                var subTitleScore = StringMatcher.FuzzySearch(query.Search, c.SubTitle).ScoreAfterSearchPrecisionFilter();
-                var score = Math.Max(titleScore, subTitleScore);
+                var titleMatch = StringMatcher.FuzzySearch(query.Search, c.Title);
+                var subTitleMatch = StringMatcher.FuzzySearch(query.Search, c.SubTitle);
+
+                var score = Math.Max(titleMatch.Score, subTitleMatch.Score);
                 if (score > 0)
                 {
                     c.Score = score;
+                    if (score == titleMatch.Score)
+                    {
+                        c.TitleHighlightData = titleMatch.MatchData;
+                    }
+                    else 
+                    {
+                        c.SubTitleHighlightData = subTitleMatch.MatchData;
+                    }
                     results.Add(c);
                 }
             }

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -15,15 +15,12 @@ namespace Wox.Infrastructure
         private static readonly HanyuPinyinOutputFormat Format = new HanyuPinyinOutputFormat();
         private static ConcurrentDictionary<string, string[][]> PinyinCache;
         private static BinaryStorage<ConcurrentDictionary<string, string[][]>> _pinyinStorage;
-        private static bool _shouldUsePinyin = true;
+        private static Settings _settings;
          
-        public static void Initialize(bool shouldUsePinyin = true)
+        public static void Initialize(Settings settings)
         {
-            _shouldUsePinyin = shouldUsePinyin;
-            if (_shouldUsePinyin)
-            {
-                InitializePinyinHelpers();
-            }
+            _settings = settings;
+            InitializePinyinHelpers();
         }
 
         private static void InitializePinyinHelpers()
@@ -43,7 +40,7 @@ namespace Wox.Infrastructure
 
         public static void Save()
         {
-            if (!_shouldUsePinyin)
+            if (!_settings.ShouldUsePinyin)
             {
                 return; 
             }
@@ -59,7 +56,7 @@ namespace Wox.Infrastructure
         /// </summary>
         public static string[] Pinyin(string word)
         {
-            if (!_shouldUsePinyin)
+            if (!_settings.ShouldUsePinyin)
             {
                 return EmptyStringArray;
             }
@@ -81,7 +78,7 @@ namespace Wox.Infrastructure
         /// </summmary>
         public static string[][] PinyinComination(string characters)
         {
-            if (!_shouldUsePinyin || string.IsNullOrEmpty(characters))
+            if (!_settings.ShouldUsePinyin || string.IsNullOrEmpty(characters))
             {
                 return Empty2DStringArray;
             }
@@ -122,7 +119,7 @@ namespace Wox.Infrastructure
 
         public static bool ContainsChinese(string word)
         {
-            if (!_shouldUsePinyin)
+            if (!_settings.ShouldUsePinyin)
             {
                 return false;
             }
@@ -140,7 +137,7 @@ namespace Wox.Infrastructure
 
         private static string[] Combination(string[] array1, string[] array2)
         {
-            if (!_shouldUsePinyin)
+            if (!_settings.ShouldUsePinyin)
             {
                 return EmptyStringArray;
             }

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -149,7 +149,5 @@ namespace Wox.Infrastructure
             ).ToArray();
             return combination;
         }
-
-
     }
 }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -120,19 +120,6 @@ namespace Wox.Infrastructure
             None = 0
         }
 
-        public static bool IsSearchPrecisionScoreMet(this MatchResult matchResult)
-        {            
-            var precisionScore = (SearchPrecisionScore)Enum.Parse(typeof(SearchPrecisionScore), 
-                                                                            UserSettingSearchPrecision ?? SearchPrecisionScore.Regular.ToString());
-            return matchResult.Score >= (int)precisionScore;
-        }
-
-        public static int ScoreAfterSearchPrecisionFilter(this MatchResult matchResult)
-        {
-            return matchResult.IsSearchPrecisionScoreMet() ? matchResult.Score : 0;
-
-        }
-
         public static int ScoreForPinyin(string source, string target)
         {
             if (!string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(target))
@@ -164,12 +151,42 @@ namespace Wox.Infrastructure
     public class MatchResult
     {
         public bool Success { get; set; }
-        public int Score { get; set; }
+
+        private int _score;
+        public int Score
+        {
+            get
+            {
+                return _score;
+            }
+            set
+            {
+                _score = ApplySearchPrecisionFilter(value);
+            }
+        }
         
         /// <summary>
-        /// highlight string
+        /// Matched data to highlight.
         /// </summary>
-        public string Value { get; set; }
+        public List<int> MatchData { get; set; }
+
+        public bool IsSearchPrecisionScoreMet()
+        {
+            return IsSearchPrecisionScoreMet(Score);
+        }
+
+        private bool IsSearchPrecisionScoreMet(int score)
+        {
+            var precisionScore = (SearchPrecisionScore)Enum.Parse(
+               typeof(SearchPrecisionScore),
+               UserSettingSearchPrecision ?? SearchPrecisionScore.Regular.ToString());
+            return score >= (int)precisionScore;
+        }
+
+        private int ApplySearchPrecisionFilter(int score)
+        {
+            return IsSearchPrecisionScoreMet(score) ? score : 0;
+        }
     }
 
     public class MatchOption

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,6 +13,7 @@ namespace Wox.Infrastructure
         public static MatchOption DefaultMatchOption = new MatchOption();
 
         public static string UserSettingSearchPrecision { get; set; }
+        public static bool ShouldUsePinyin { get; set; }
 
         [Obsolete("This method is obsolete and should not be used. Please use the static function StringMatcher.FuzzySearch")]
         public static int Score(string source, string target)
@@ -135,6 +136,11 @@ namespace Wox.Infrastructure
 
         public static int ScoreForPinyin(string source, string target)
         {
+            if (!ShouldUsePinyin)
+            {
+                return 0;
+            }
+
             if (!string.IsNullOrEmpty(source) && !string.IsNullOrEmpty(target))
             {
                 if (Alphabet.ContainsChinese(source))

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -96,7 +96,7 @@ namespace Wox.Infrastructure
                 {
                     Success = true,
                     MatchData = indexList,
-                    Score = Math.Max(score, pinyinScore)
+                    RawScore = Math.Max(score, pinyinScore)
                 };
 
                 return result.Score > 0 ? 
@@ -171,16 +171,22 @@ namespace Wox.Infrastructure
     {
         public bool Success { get; set; }
 
-        private int _score;
-        public int Score
+        /// <summary>
+        /// The final score of the match result with all search precision filters applied.
+        /// </summary>
+        public int Score { get; private set; }
+
+        /// <summary>
+        /// The raw calculated search score without any search precision filtering applied.
+        /// </summary>
+        private int _rawScore;
+        public int RawScore
         {
-            get
-            {
-                return _score;
-            }
+            get { return _rawScore; }
             set
             {
-                _score = ApplySearchPrecisionFilter(value);
+                _rawScore = value;
+                Score = ApplySearchPrecisionFilter(_rawScore);
             }
         }
 

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text;
 using Wox.Infrastructure.Logger;
@@ -95,14 +95,20 @@ namespace Wox.Infrastructure
 
         private static int CalScore(string query, string stringToCompare, int firstIndex, int matchLen)
         {
-            //a match found near the beginning of a string is scored more than a match found near the end
-            //a match is scored more if the characters in the patterns are closer to each other, while the score is lower if they are more spread out
+            // A match found near the beginning of a string is scored more than a match found near the end
+            // A match is scored more if the characters in the patterns are closer to each other, 
+            // while the score is lower if they are more spread out
             var score = 100 * (query.Length + 1) / ((1 + firstIndex) + (matchLen + 1));
-            //a match with less characters assigning more weights
+
+            // A match with less characters assigning more weights
             if (stringToCompare.Length - query.Length < 5)
+            {
                 score += 20;
+            }
             else if (stringToCompare.Length - query.Length < 10)
+            {
                 score += 10;
+            }
 
             return score;
         }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -99,9 +99,7 @@ namespace Wox.Infrastructure
                     RawScore = Math.Max(score, pinyinScore)
                 };
 
-                return result.Score > 0 ? 
-                    result : 
-                    new MatchResult { Success = false };
+                return result;
             }
 
             return new MatchResult { Success = false };

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -24,7 +24,17 @@ namespace Wox.Infrastructure.UserSettings
         /// <summary>
         /// when false Alphabet static service will always return empty results
         /// </summary>
-        public bool ShouldUsePinyin { get; set; } = true;
+        private bool _shouldUsePinyin = true;
+        public bool ShouldUsePinyin 
+        {
+            get { return _shouldUsePinyin;  }
+            set 
+            {
+                _shouldUsePinyin = value;
+                StringMatcher.ShouldUsePinyin = value;
+            }
+        }
+
 
         private string _querySearchPrecision { get; set; } = StringMatcher.SearchPrecisionScore.Regular.ToString();
         public string QuerySearchPrecision

--- a/Wox.Plugin/Result.cs
+++ b/Wox.Plugin/Result.cs
@@ -43,6 +43,16 @@ namespace Wox.Plugin
         public int Score { get; set; }
 
         /// <summary>
+        /// A list of indexes for the characters to be highlighted in Title
+        /// </summary>
+        public IList<int> TitleHighlightData { get; set; }
+
+        /// <summary>
+        /// A list of indexes for the characters to be highlighted in SubTitle
+        /// </summary>
+        public IList<int> SubTitleHighlightData { get; set; }
+
+        /// <summary>
         /// Only resulsts that originQuery match with curren query will be displayed in the panel
         /// </summary>
         internal Query OriginQuery { get; set; }
@@ -69,7 +79,9 @@ namespace Wox.Plugin
 
             var equality = string.Equals(r?.Title, Title) &&
                            string.Equals(r?.SubTitle, SubTitle) &&
-                           string.Equals(r?.IcoPath, IcoPath);
+                           string.Equals(r?.IcoPath, IcoPath) &&
+                           TitleHighlightData == r.TitleHighlightData &&
+                           SubTitleHighlightData == r.SubTitleHighlightData;
 
             return equality;
         }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using Wox.Infrastructure;
+using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
 
 namespace Wox.Test
@@ -48,6 +49,8 @@ namespace Wox.Test
                 "aac"
             };
 
+            Alphabet.Initialize(false);
+            StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.Low.ToString();
 
             var results = new List<Result>();
             foreach (var str in sources)
@@ -130,6 +133,9 @@ namespace Wox.Test
 
             var results = new List<Result>();
 
+            Alphabet.Initialize(false);
+            StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.None.ToString();
+
             foreach (var str in searchStrings)
             {
                 results.Add(new Result
@@ -168,8 +174,11 @@ namespace Wox.Test
         [TestCase("ccs", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Low, true)]
         [TestCase("cand", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("cand", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        public void WhenGivenDesiredPrecisionThenShouldReturnAllResultsGreaterOrEqual(string queryString, string compareString, 
-                                                                                                        int expectedPrecisionScore, bool expectedPrecisionResult)
+        public void WhenGivenDesiredPrecisionThenShouldReturnAllResultsGreaterOrEqual(
+            string queryString, 
+            string compareString, 
+            int expectedPrecisionScore, 
+            bool expectedPrecisionResult)
         {
             var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;            
             StringMatcher.UserSettingSearchPrecision = expectedPrecisionString.ToString();

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -12,7 +12,7 @@ namespace Wox.Test
     [TestFixture]
     public class FuzzyMatcherTest
     {
-        public List<string> GetSearchStrings() 
+        public List<string> GetSearchStrings()
             => new List<string>
             {
                 "Chrome",
@@ -49,16 +49,13 @@ namespace Wox.Test
                 "aac"
             };
 
-            Alphabet.Initialize(false);
-            StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.Low.ToString();
-
             var results = new List<Result>();
             foreach (var str in sources)
             {
                 results.Add(new Result
                 {
                     Title = str,
-                    Score = StringMatcher.FuzzySearch("inst", str).Score
+                    Score = StringMatcher.FuzzySearch("inst", str).RawScore
                 });
             }
 
@@ -75,7 +72,7 @@ namespace Wox.Test
         {
             var compareString = "Can have rum only in my glass";
 
-            var scoreResult = StringMatcher.FuzzySearch(searchString, compareString).Score;
+            var scoreResult = StringMatcher.FuzzySearch(searchString, compareString).RawScore;
 
             Assert.True(scoreResult == 0);
         }
@@ -132,16 +129,12 @@ namespace Wox.Test
             .ToList();
 
             var results = new List<Result>();
-
-            Alphabet.Initialize(false);
-            StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.None.ToString();
-
             foreach (var str in searchStrings)
             {
                 results.Add(new Result
                 {
                     Title = str,
-                    Score = StringMatcher.FuzzySearch(searchTerm, str).Score
+                    Score = StringMatcher.FuzzySearch(searchTerm, str).RawScore
                 });
             }
 

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Timers;
@@ -53,7 +53,7 @@ namespace Wox
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
 
-                Alphabet.Initialize(_settings);
+                Alphabet.Initialize(_settings.ShouldUsePinyin);
 
                 StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
 

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -53,7 +53,7 @@ namespace Wox
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
 
-                Alphabet.Initialize(_settings.ShouldUsePinyin);
+                Alphabet.Initialize(_settings);
 
                 StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
 

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -56,6 +56,7 @@ namespace Wox
                 Alphabet.Initialize(_settings);
 
                 StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
+                StringMatcher.ShouldUsePinyin = _settings.ShouldUsePinyin;
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);
                 _mainVM = new MainViewModel(_settings);

--- a/Wox/Converters/HighlightTextConverter.cs
+++ b/Wox/Converters/HighlightTextConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Documents;
+
+namespace Wox.Converters
+{
+    public class HighlightTextConverter : IMultiValueConverter
+    {
+        public object Convert(object[] value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+            var text = value[0] as string;
+            var highlightData = value[1] as List<int>;
+
+            var textBlock = new Span();
+
+            if (highlightData == null || !highlightData.Any())
+            {
+                // No highlight data, just return the text
+                return new Run(text);
+            }
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                var currentCharacter = text.Substring(i, 1);
+                if (this.ShouldHighlight(highlightData, i))
+                {
+                    textBlock.Inlines.Add(new Bold(new Run(currentCharacter)));
+                }
+                else
+                {
+                    textBlock.Inlines.Add(new Run(currentCharacter));
+                }
+            }
+            return textBlock;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
+        {
+            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+        }
+
+        private bool ShouldHighlight(List<int> highlightData, int index)
+        {
+            return highlightData.Contains(index);
+        }
+    }
+}

--- a/Wox/ResultListBox.xaml
+++ b/Wox/ResultListBox.xaml
@@ -4,6 +4,7 @@
          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
          xmlns:vm="clr-namespace:Wox.ViewModel"
+         xmlns:converter="clr-namespace:Wox.Converters"
          mc:Ignorable="d" d:DesignWidth="100" d:DesignHeight="100"
          d:DataContext="{d:DesignInstance vm:ResultsViewModel}"
          MaxHeight="{Binding MaxHeight}"
@@ -30,6 +31,9 @@
                 <Button.Content>
                     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="5"
                           Cursor="Hand" UseLayoutRounding="False">
+                        <Grid.Resources>
+                            <converter:HighlightTextConverter x:Key="HighlightTextConverter"/>
+                        </Grid.Resources>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="32" />
                             <ColumnDefinition />
@@ -44,9 +48,23 @@
                             </Grid.RowDefinitions>
                             <TextBlock Style="{DynamicResource ItemTitleStyle}" DockPanel.Dock="Left"
                                        VerticalAlignment="Center" ToolTip="{Binding Result.Title}" x:Name="Title"
-                                       Text="{Binding Result.Title}" />
+                                       Text="{Binding Result.Title}">
+                                <vm:ResultsViewModel.FormattedText>
+                                    <MultiBinding Converter="{StaticResource HighlightTextConverter}">
+                                        <Binding Path="Result.Title" />
+                                        <Binding Path="Result.TitleHighlightData" />
+                                    </MultiBinding>
+                                </vm:ResultsViewModel.FormattedText>
+                            </TextBlock>
                             <TextBlock Style="{DynamicResource ItemSubTitleStyle}" ToolTip="{Binding Result.SubTitle}"
-                                       Grid.Row="1" x:Name="SubTitle" Text="{Binding Result.SubTitle}" />
+                                       Grid.Row="1" x:Name="SubTitle" Text="{Binding Result.SubTitle}">
+                                <vm:ResultsViewModel.FormattedText>
+                                    <MultiBinding Converter="{StaticResource HighlightTextConverter}">
+                                        <Binding Path="Result.SubTitle" />
+                                        <Binding Path="Result.SubTitleHighlightData" />
+                                    </MultiBinding>
+                                </vm:ResultsViewModel.FormattedText>
+                            </TextBlock>
                         </Grid>
                     </Grid>
                 </Button.Content>

--- a/Wox/ViewModel/RelayCommand.cs
+++ b/Wox/ViewModel/RelayCommand.cs
@@ -5,7 +5,6 @@ namespace Wox.ViewModel
 {
     public class RelayCommand : ICommand
     {
-
         private Action<object> _action;
 
         public RelayCommand(Action<object> action)

--- a/Wox/ViewModel/ResultsViewModel.cs
+++ b/Wox/ViewModel/ResultsViewModel.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Documents;
 using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
 
@@ -193,8 +195,37 @@ namespace Wox.ViewModel
 
             return results;
         }
+        #endregion
 
+        #region FormattedText Dependency Property
+        public static readonly DependencyProperty FormattedTextProperty = DependencyProperty.RegisterAttached(
+            "FormattedText",
+            typeof(Inline),
+            typeof(ResultsViewModel),
+            new PropertyMetadata(null, FormattedTextPropertyChanged));
 
+        public static void SetFormattedText(DependencyObject textBlock, IList<int> value)
+        {
+            textBlock.SetValue(FormattedTextProperty, value);
+        }
+
+        public static Inline GetFormattedText(DependencyObject textBlock)
+        {
+            return (Inline)textBlock.GetValue(FormattedTextProperty);
+        }
+
+        private static void FormattedTextPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var textBlock = d as TextBlock;
+            if (textBlock == null) return;
+
+            var inline = (Inline)e.NewValue;
+
+            textBlock.Inlines.Clear();
+            if (inline == null) return;
+
+            textBlock.Inlines.Add(inline);
+        }
         #endregion
 
         public class ResultCollection : ObservableCollection<ResultViewModel>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -158,6 +158,7 @@
     <Compile Include="..\SolutionAssemblyInfo.cs">
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Converters\HighlightTextConverter.cs" />
     <Compile Include="Helper\SingletonWindowOpener.cs" />
     <Compile Include="PublicAPIInstance.cs" />
     <Compile Include="ReportWindow.xaml.cs" />


### PR DESCRIPTION
Closes #81 

![image](https://user-images.githubusercontent.com/8371978/70078864-d7d51380-1603-11ea-8ceb-2823c93f1168.png)

I made a couple of additional changes:
- The search precision filter is now applied directly when a Score is applied. 
- The score comparison between pinyin / other is made directly in the MatchResult.