### PR TITLE
Add option to run as administrator for Shell plugin

### DIFF
--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -10,6 +10,7 @@ using Microsoft.Win32;
 using Shell;
 using Wox.Infrastructure;
 using Wox.Plugin.Program.Logger;
+using Wox.Plugin.SharedCommands;
 
 namespace Wox.Plugin.Program.Programs
 {
@@ -96,14 +97,7 @@ namespace Wox.Plugin.Program.Programs
                     Title = api.GetTranslation("wox_plugin_program_run_as_administrator"),
                     Action = _ =>
                     {
-                        var info = new ProcessStartInfo
-                        {
-                            FileName = FullPath,
-                            WorkingDirectory = ParentDirectory,
-                            Verb = "runas"
-                        };
-                        var hide = Main.StartProcess(info);
-                        return hide;
+                        return Main.StartProcess(ShellCommand.SetCMDRunAsAdministrator(FullPath, ParentDirectory));
                     },
                     IcoPath = "Images/cmd.png"
                 },

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -10,7 +10,6 @@ using Microsoft.Win32;
 using Shell;
 using Wox.Infrastructure;
 using Wox.Plugin.Program.Logger;
-using Wox.Plugin.SharedCommands;
 
 namespace Wox.Plugin.Program.Programs
 {
@@ -97,7 +96,14 @@ namespace Wox.Plugin.Program.Programs
                     Title = api.GetTranslation("wox_plugin_program_run_as_administrator"),
                     Action = _ =>
                     {
-                        return Main.StartProcess(ShellCommand.SetProcessStartInfo(FullPath, ParentDirectory));
+                        var info = new ProcessStartInfo
+                        {
+                            FileName = FullPath,
+                            WorkingDirectory = ParentDirectory,
+                            Verb = "runas"
+                        };
+                        var hide = Main.StartProcess(info);
+                        return hide;
                     },
                     IcoPath = "Images/cmd.png"
                 },

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -97,7 +97,7 @@ namespace Wox.Plugin.Program.Programs
                     Title = api.GetTranslation("wox_plugin_program_run_as_administrator"),
                     Action = _ =>
                     {
-                        return Main.StartProcess(ShellCommand.SetCMDRunAsAdministrator(FullPath, ParentDirectory));
+                        return Main.StartProcess(ShellCommand.SetProcessStartInfo(FullPath, ParentDirectory));
                     },
                     IcoPath = "Images/cmd.png"
                 },

--- a/Plugins/Wox.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Wox.Plugin.Shell/Languages/en.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="wox_plugin_cmd_relace_winr">Replace Win+R</system:String>
     <system:String x:Key="wox_plugin_cmd_leave_cmd_open">Do not close Command Prompt after command execution</system:String>
+    <system:String x:Key="wox_plugin_cmd_always_run_as_administrator">Always run as administrator</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_name">Shell</system:String>
     <system:String x:Key="wox_plugin_cmd_plugin_description">Allows to execute system commands from Wox. Commands should start with ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">this command has been executed {0} times</system:String>

--- a/Plugins/Wox.Plugin.Shell/Settings.cs
+++ b/Plugins/Wox.Plugin.Shell/Settings.cs
@@ -7,7 +7,7 @@ namespace Wox.Plugin.Shell
         public Shell Shell { get; set; } = Shell.Cmd;
         public bool ReplaceWinR { get; set; } = true;
         public bool LeaveShellOpen { get; set; }
-        internal bool RunAsAdministrator { get; set; } = true;
+        public bool RunAsAdministrator { get; set; } = true;
 
         public Dictionary<string, int> Count = new Dictionary<string, int>();
 

--- a/Plugins/Wox.Plugin.Shell/Settings.cs
+++ b/Plugins/Wox.Plugin.Shell/Settings.cs
@@ -7,6 +7,8 @@ namespace Wox.Plugin.Shell
         public Shell Shell { get; set; } = Shell.Cmd;
         public bool ReplaceWinR { get; set; } = true;
         public bool LeaveShellOpen { get; set; }
+        internal bool RunAsAdministrator { get; set; } = true;
+
         public Dictionary<string, int> Count = new Dictionary<string, int>();
 
         public void AddCmdHistory(string cmdName)

--- a/Plugins/Wox.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Wox.Plugin.Shell/ShellSetting.xaml
@@ -12,10 +12,12 @@
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <CheckBox Grid.Row="0" x:Name="ReplaceWinR" Content="{DynamicResource wox_plugin_cmd_relace_winr}" Margin="10" HorizontalAlignment="Left"/>
             <CheckBox Grid.Row="1" x:Name="LeaveShellOpen" Content="{DynamicResource wox_plugin_cmd_leave_cmd_open}" Margin="10" HorizontalAlignment="Left"/>
-            <ComboBox Grid.Row="2" x:Name="ShellComboBox" Margin="10" HorizontalAlignment="Left" >
+            <CheckBox Grid.Row="2" x:Name="AlwaysRunAsAdministrator" Content="{DynamicResource wox_plugin_cmd_always_run_as_administrator}" Margin="10" HorizontalAlignment="Left"/>
+            <ComboBox Grid.Row="3" x:Name="ShellComboBox" Margin="10" HorizontalAlignment="Left" >
                 <ComboBoxItem>CMD</ComboBoxItem>
                 <ComboBoxItem>PowerShell</ComboBoxItem>
                 <ComboBoxItem>RunCommand</ComboBoxItem>

--- a/Plugins/Wox.Plugin.Shell/ShellSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.Shell/ShellSetting.xaml.cs
@@ -17,6 +17,7 @@ namespace Wox.Plugin.Shell
         {
             ReplaceWinR.IsChecked = _settings.ReplaceWinR;
             LeaveShellOpen.IsChecked = _settings.LeaveShellOpen;
+            AlwaysRunAsAdministrator.IsChecked = _settings.RunAsAdministrator;
             LeaveShellOpen.IsEnabled = _settings.Shell != Shell.RunCommand;
 
             LeaveShellOpen.Checked += (o, e) =>
@@ -27,6 +28,16 @@ namespace Wox.Plugin.Shell
             LeaveShellOpen.Unchecked += (o, e) =>
             {
                 _settings.LeaveShellOpen = false;
+            };
+
+            AlwaysRunAsAdministrator.Checked += (o, e) =>
+            {
+                _settings.RunAsAdministrator = true;
+            };
+
+            AlwaysRunAsAdministrator.Unchecked += (o, e) =>
+            {
+                _settings.RunAsAdministrator = false;
             };
 
             ReplaceWinR.Checked += (o, e) =>

--- a/Wox.Plugin/SharedCommands/ShellCommand.cs
+++ b/Wox.Plugin/SharedCommands/ShellCommand.cs
@@ -9,13 +9,14 @@ namespace Wox.Plugin.SharedCommands
 {
     public static class ShellCommand
     {
-        public static ProcessStartInfo SetCMDRunAsAdministrator(this string fullPath, string parentDirectory)
+        public static ProcessStartInfo SetProcessStartInfo(this string fileName, string workingDirectory="", string arguments = "", string verb = "")
         {
             var info = new ProcessStartInfo
             {
-                FileName = fullPath,
-                WorkingDirectory = parentDirectory,
-                Verb = "runas"
+                FileName = fileName,
+                WorkingDirectory = workingDirectory,
+                Arguments = arguments,
+                Verb = verb
             };
 
             return info;

--- a/Wox.Plugin/SharedCommands/ShellCommand.cs
+++ b/Wox.Plugin/SharedCommands/ShellCommand.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wox.Plugin.SharedCommands
+{
+    public static class ShellCommand
+    {
+        public static ProcessStartInfo SetCMDRunAsAdministrator(this string fullPath, string parentDirectory)
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = fullPath,
+                WorkingDirectory = parentDirectory,
+                Verb = "runas"
+            };
+
+            return info;
+        }
+    }
+}

--- a/Wox.Plugin/Wox.Plugin.csproj
+++ b/Wox.Plugin/Wox.Plugin.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Result.cs" />
     <Compile Include="ActionContext.cs" />
     <Compile Include="SharedCommands\SearchWeb.cs" />
+    <Compile Include="SharedCommands\ShellCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Add the option for the user to allow Shell plugin to run CMD and Powershell commands always
 as administrator.