### PR TITLE
Fix exceptions in Folder plugin search + other fixes

### DIFF
--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -157,18 +157,32 @@ namespace Wox.Plugin.Folder
                 incompleteName = incompleteName.Substring(1);
             }
 
-            // search folder and add results
-            var fileSystemInfos = directoryInfo.GetFileSystemInfos(incompleteName, searchOption);
-
-            foreach (var fileSystemInfo in fileSystemInfos)
+            try
             {
-                if ((fileSystemInfo.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden) continue;
+                // search folder and add results
+                var fileSystemInfos = directoryInfo.GetFileSystemInfos(incompleteName, searchOption);
 
-                var result =
-                    fileSystemInfo is DirectoryInfo
-                        ? CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName, query.ActionKeyword)
-                        : CreateFileResult(fileSystemInfo.FullName);
-                results.Add(result);
+                foreach (var fileSystemInfo in fileSystemInfos)
+                {
+                    if ((fileSystemInfo.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden) continue;
+
+                    var result =
+                        fileSystemInfo is DirectoryInfo
+                            ? CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName, query.ActionKeyword)
+                            : CreateFileResult(fileSystemInfo.FullName);
+                    results.Add(result);
+                }
+            }
+            catch(Exception e)
+            {
+                if (e is UnauthorizedAccessException || e is ArgumentException)
+                {
+                    results.Add(new Result { Title = e.Message, Score = 501 });
+
+                    return results;
+                }
+
+                throw;
             }
 
             return results;

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -220,7 +220,7 @@ namespace Wox.Plugin.Folder
             {
                 Title = firstResult,
                 IcoPath = search,
-                Score = 10000,
+                Score = 500,
                 Action = c =>
                 {
                     Process.Start(search);

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -82,7 +82,7 @@ namespace Wox.Plugin.Folder
                     }
 
                     string changeTo = path.EndsWith("\\") ? path : path + "\\";
-                    _context.API.ChangeQuery(queryActionKeyword + " " + changeTo);
+                    _context.API.ChangeQuery(string.IsNullOrEmpty(queryActionKeyword)? changeTo : queryActionKeyword + " " + changeTo);
                     return false;
                 }
             };


### PR DESCRIPTION
- Add exception thrown when using Special Search Characters are used to search, which could iterate through folders which not authorised. Added also handling if path is amended by user with Special Search Characters which will throw arg exception
- Add handling when query action key word is not used which result in empty action keyword
 - Lower the score for folder results

Fixes errors from https://github.com/jjw24/Wox/pull/90, https://github.com/jjw24/Wox/pull/88