### PR TITLE
For Program plugin hide context menu immediately after selected run as administrator

### DIFF
--- a/Plugins/Wox.Plugin.Program/Main.cs
+++ b/Plugins/Wox.Plugin.Program/Main.cs
@@ -191,22 +191,19 @@ namespace Wox.Plugin.Program
                          );
         }
 
-        public static bool StartProcess(Func<ProcessStartInfo, Process> runProcess, ProcessStartInfo info)
+        public static void StartProcess(Func<ProcessStartInfo, Process> runProcess, ProcessStartInfo info)
         {
             bool hide;
             try
             {
                 runProcess(info);
-                hide = true;
             }
             catch (Exception)
             {
                 var name = "Plugin: Program";
-                var message = $"Can't start: {info.FileName}";
+                var message = $"Unable to start: {info.FileName}";
                 _context.API.ShowMsg(name, message, string.Empty);
-                hide = false;
             }
-            return hide;
         }
 
         public void ReloadData()

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -319,11 +319,14 @@ namespace Wox.Plugin.Program.Programs
                     new Result
                     {
                         Title = api.GetTranslation("wox_plugin_program_open_containing_folder"),
+
                         Action = _ =>
                         {
-                            var hide = Main.StartProcess(Process.Start, new ProcessStartInfo(Package.Location));
-                            return hide;
+                            Main.StartProcess(Process.Start, new ProcessStartInfo(Package.Location));
+
+                            return true;
                         },
+
                         IcoPath = "Images/folder.png"
                     }
                 };

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -121,8 +121,10 @@ namespace Wox.Plugin.Program.Programs
                             WorkingDirectory = ParentDirectory,
                             Verb = "runas"
                         };
-                        var hide = Main.StartProcess(Process.Start, info);
-                        return hide;
+
+                        Task.Run(() => Main.StartProcess(Process.Start, info));
+
+                        return true;
                     },
                     IcoPath = "Images/cmd.png"
                 },

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -64,8 +64,10 @@ namespace Wox.Plugin.Program.Programs
                         FileName = FullPath,
                         WorkingDirectory = ParentDirectory
                     };
-                    var hide = Main.StartProcess(Process.Start, info);
-                    return hide;
+
+                    Main.StartProcess(Process.Start, info);
+
+                    return true;
                 }
             };
 
@@ -129,8 +131,9 @@ namespace Wox.Plugin.Program.Programs
                     Title = api.GetTranslation("wox_plugin_program_open_containing_folder"),
                     Action = _ =>
                     {
-                        var hide = Main.StartProcess(Process.Start, new ProcessStartInfo(ParentDirectory));
-                        return hide;
+                        Main.StartProcess(Process.Start, new ProcessStartInfo(ParentDirectory));
+
+                        return true;
                     },
                     IcoPath = "Images/folder.png"
                 }


### PR DESCRIPTION
For better user experience, hide the context menu once user has selected to run as administrator. Previous behavior keeps the menu shown and waited until user selected to allow the program to run as administrator from system prompt (Win10).

Also removed obsolete bool return on Process.Start as hiding window is now delegated to the MainWindow's OnDeactivated call