### PR TITLE
Better search experience and more accurate results

### DIFF
--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -145,7 +145,7 @@ namespace Wox.Test
             Debug.WriteLine("SEARCHTERM: " + searchTerm);
             foreach (var item in orderedResults)
             {
-                Debug.WriteLine("SCORE: " + item.Score.ToString() + ", FoundString: " + item.Title);
+                Debug.WriteLine("RAW SCORE: " + item.Score.ToString() + ", FoundString: " + item.Title);
             }
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
@@ -173,18 +173,18 @@ namespace Wox.Test
             int expectedPrecisionScore, 
             bool expectedPrecisionResult)
         {
-            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;            
+            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;
             StringMatcher.UserSettingSearchPrecision = expectedPrecisionString.ToString();
             var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
-            Debug.WriteLine($"SearchTerm: {queryString} PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
-            Debug.WriteLine($"SCORE: {matchResult.Score.ToString()}, ComparedString: {compareString}");
+            Debug.WriteLine($"SearchTerm: {queryString}     ComparedString: {compareString}");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
 
-            var matchPrecisionResult = matchResult.IsSearchPrecisionScoreMet();            
+            var matchPrecisionResult = matchResult.IsSearchPrecisionScoreMet();
             Assert.IsTrue(matchPrecisionResult == expectedPrecisionResult);
         }
     }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -193,12 +193,12 @@ namespace Wox.Test
         [TestCase("sql s managa", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
         [TestCase("sql' s manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
         [TestCase("sql s manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("sql", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("test", "This is a test", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("chr", "Shutdown", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("mic", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Shutdown", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("test", "This is a test", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         public void WhenGivenQueryShouldReturnResultsContainingAllQuerySubstrings(
             string queryString,
             string compareString,

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -187,5 +187,37 @@ namespace Wox.Test
             var matchPrecisionResult = matchResult.IsSearchPrecisionScoreMet();
             Assert.IsTrue(matchPrecisionResult == expectedPrecisionResult);
         }
+
+        [TestCase("exce", "OverLeaf-Latex: An online LaTeX editor", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("term", "Windows Terminal (Preview)", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql s managa", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql' s manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql s manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql manag", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("test", "This is a test", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Shutdown", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("mic", "Microsoft SQL Server Management Studio", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        public void WhenGivenQueryShouldReturnResultsContainingAllQuerySubstrings(
+            string queryString,
+            string compareString,
+            int expectedPrecisionScore,
+            bool expectedPrecisionResult)
+        {
+            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;
+            StringMatcher.UserSettingSearchPrecision = expectedPrecisionString.ToString();
+            var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
+
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
+
+            var matchPrecisionResult = matchResult.IsSearchPrecisionScoreMet();
+            Assert.IsTrue(matchPrecisionResult == expectedPrecisionResult);
+        }
     }
 }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -179,7 +179,7 @@ namespace Wox.Test
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
-            Debug.WriteLine($"SearchTerm: {queryString}     ComparedString: {compareString}");
+            Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
             Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");


### PR DESCRIPTION
Problem context:
1. Wox's search mechanism uses character matching- in a given query string "sql" matching with program title compare string "Microsoft SQL Management Studio" scenario, the match fails for 'Regular' search precision level. This is due to 'RawScore' obtain as 26, not enough to make the Score required for 'Regular' search precision level of 50.

2. Searching for results that may contain partial words such as "term" should return "Windows Terminal' without having to type in "Windows Te".

Just an overall more nature searching experience while retaining the capability of using character search as well.

Also fixes issues https://github.com/jjw24/Wox/issues/84 & https://github.com/jjw24/Wox/issues/92