### PR TITLE
Fuzzy match logic update

### DIFF
--- a/Wox.Infrastructure/Logger/Log.cs
+++ b/Wox.Infrastructure/Logger/Log.cs
@@ -47,8 +47,53 @@ namespace Wox.Infrastructure.Logger
             return valid;
         }
 
-        /// <param name="message">example: "|prefix|unprefixed" </param>
-        public static void Error(string message)
+        
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public static void Exception(string className, string message, System.Exception exception, [CallerMemberName] string methodName = "")
+        {
+            if (string.IsNullOrWhiteSpace(className))
+            {
+                LogFaultyFormat($"Fail to specify a class name during logging of message: {message ?? "no message entered"}");
+            }
+
+            if (string.IsNullOrWhiteSpace(message))
+            { // todo: not sure we really need that
+                LogFaultyFormat($"Fail to specify a message during logging");
+            }
+
+            if (!string.IsNullOrWhiteSpace(methodName))
+            {
+                className += "." + methodName;
+            }
+
+            ExceptionInternal(className, message, exception);
+        }
+
+        private static void ExceptionInternal(string classAndMethod, string message, System.Exception e)
+        {
+            var logger = LogManager.GetLogger(classAndMethod);
+
+            System.Diagnostics.Debug.WriteLine($"ERROR|{message}");
+
+            logger.Error("-------------------------- Begin exception --------------------------");
+            logger.Error(message);
+
+            do
+            {
+                logger.Error($"Exception full name:\n <{e.GetType().FullName}>");
+                logger.Error($"Exception message:\n <{e.Message}>");
+                logger.Error($"Exception stack trace:\n <{e.StackTrace}>");
+                logger.Error($"Exception source:\n <{e.Source}>");
+                logger.Error($"Exception target site:\n <{e.TargetSite}>");
+                logger.Error($"Exception HResult:\n <{e.HResult}>");
+                e = e.InnerException;
+            } while (e != null);
+
+            logger.Error("-------------------------- End exception --------------------------");
+        }
+
+        private static void LogInternal(string message, LogLevel level)
         {
             if (FormatValid(message))
             {
@@ -57,8 +102,8 @@ namespace Wox.Infrastructure.Logger
                 var unprefixed = parts[2];
                 var logger = LogManager.GetLogger(prefix);
 
-                System.Diagnostics.Debug.WriteLine($"ERROR|{message}");
-                logger.Error(unprefixed);
+                System.Diagnostics.Debug.WriteLine($"{level.Name}|{message}");
+                logger.Log(level, unprefixed);
             }
             else
             {
@@ -78,25 +123,7 @@ namespace Wox.Infrastructure.Logger
                 var parts = message.Split('|');
                 var prefix = parts[1];
                 var unprefixed = parts[2];
-                var logger = LogManager.GetLogger(prefix);
-
-                System.Diagnostics.Debug.WriteLine($"ERROR|{message}");
-
-                logger.Error("-------------------------- Begin exception --------------------------");
-                logger.Error(unprefixed);
-
-                do
-                {
-                    logger.Error($"Exception full name:\n <{e.GetType().FullName}>");
-                    logger.Error($"Exception message:\n <{e.Message}>");
-                    logger.Error($"Exception stack trace:\n <{e.StackTrace}>");
-                    logger.Error($"Exception source:\n <{e.Source}>");
-                    logger.Error($"Exception target site:\n <{e.TargetSite}>");
-                    logger.Error($"Exception HResult:\n <{e.HResult}>");
-                    e = e.InnerException;
-                } while (e != null);
-
-                logger.Error("-------------------------- End exception --------------------------");
+                ExceptionInternal(prefix, unprefixed, e);
             }
             else
             {
@@ -104,62 +131,29 @@ namespace Wox.Infrastructure.Logger
             }
 #endif
         }
-        
+
+        /// <param name="message">example: "|prefix|unprefixed" </param>
+        public static void Error(string message)
+        {
+            LogInternal(message, LogLevel.Error);
+        }
+
         /// <param name="message">example: "|prefix|unprefixed" </param>
         public static void Debug(string message)
         {
-            if (FormatValid(message))
-            {
-                var parts = message.Split('|');
-                var prefix = parts[1];
-                var unprefixed = parts[2];
-                var logger = LogManager.GetLogger(prefix);
-
-                System.Diagnostics.Debug.WriteLine($"DEBUG|{message}");
-                logger.Debug(unprefixed);
-            }
-            else
-            {
-                LogFaultyFormat(message);
-            }
+            LogInternal(message, LogLevel.Debug);
         }
 
         /// <param name="message">example: "|prefix|unprefixed" </param>
         public static void Info(string message)
         {
-            if (FormatValid(message))
-            {
-                var parts = message.Split('|');
-                var prefix = parts[1];
-                var unprefixed = parts[2];
-                var logger = LogManager.GetLogger(prefix);
-
-                System.Diagnostics.Debug.WriteLine($"INFO|{message}");
-                logger.Info(unprefixed);
-            }
-            else
-            {
-                LogFaultyFormat(message);
-            }
+            LogInternal(message, LogLevel.Info);
         }
 
         /// <param name="message">example: "|prefix|unprefixed" </param>
         public static void Warn(string message)
         {
-            if (FormatValid(message))
-            {
-                var parts = message.Split('|');
-                var prefix = parts[1];
-                var unprefixed = parts[2];
-                var logger = LogManager.GetLogger(prefix);
-
-                System.Diagnostics.Debug.WriteLine($"WARN|{message}");
-                logger.Warn(unprefixed);
-            }
-            else
-            {
-                LogFaultyFormat(message);
-            }
+            LogInternal(message, LogLevel.Warn);
         }
     }
 }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -52,12 +52,12 @@ namespace Wox.Infrastructure
             var fullStringToCompareWithoutCase = opt.IgnoreCase ? stringToCompare.ToLower() : stringToCompare;
 
             var queryWithoutCase = opt.IgnoreCase ? query.ToLower() : query;
+            
+            var separatedqueryStrings = queryWithoutCase.Split(' ');
+            int currentSeparatedQueryStringIndex = 0;
+            var currentSeparatedQueryString = separatedqueryStrings[currentSeparatedQueryStringIndex];
 
-            int currentQueryToCompareIndex = 0;
-            var queryToCompareSeparated = queryWithoutCase.Split(' ');
-            var currentQueryToCompare = queryToCompareSeparated[currentQueryToCompareIndex];
-
-            var patternIndex = 0;
+            var queryIndex = 0;
             var firstMatchIndex = -1;
             var firstMatchIndexInWord = -1;
             var lastMatchIndex = 0;
@@ -70,14 +70,14 @@ namespace Wox.Infrastructure
             for (var index = 0; index < fullStringToCompareWithoutCase.Length; index++)
             {
                 var ch = stringToCompare[index];
-                if (fullStringToCompareWithoutCase[index] == currentQueryToCompare[patternIndex])
+                if (fullStringToCompareWithoutCase[index] == currentSeparatedQueryString[queryIndex])
                 {
                     if (firstMatchIndex < 0)
                     { // first matched char will become the start of the compared string
                         firstMatchIndex = index;
                     }
 
-                    if (patternIndex == 0)
+                    if (queryIndex == 0)
                     { // first letter of current word
                         isFullWordMatched = true;
                         firstMatchIndexInWord = index;
@@ -85,12 +85,12 @@ namespace Wox.Infrastructure
                     else if (!isFullWordMatched)
                     { // we want to verify that there is not a better match if this is not a full word
                         // in order to do so we need to verify all previous chars are part of the pattern
-                        int startIndexToVerify = index - patternIndex;
+                        int startIndexToVerify = index - queryIndex;
                         bool allMatch = true;
-                        for (int indexToCheck = 0; indexToCheck < patternIndex; indexToCheck++)
+                        for (int indexToCheck = 0; indexToCheck < queryIndex; indexToCheck++)
                         {   
                             if (fullStringToCompareWithoutCase[startIndexToVerify + indexToCheck] !=
-                                currentQueryToCompare[indexToCheck])
+                                currentSeparatedQueryString[indexToCheck])
                             {
                                 allMatch = false;
                             }
@@ -99,13 +99,13 @@ namespace Wox.Infrastructure
                         if (allMatch)
                         { // update to this as a full word
                             isFullWordMatched = true;
-                            if (currentQueryToCompareIndex == 0)
+                            if (currentSeparatedQueryStringIndex == 0)
                             { // first word so we need to update start index
                                 firstMatchIndex = startIndexToVerify;
                             }
 
                             indexList.RemoveAll(x => x >= firstMatchIndexInWord);
-                            for (int indexToCheck = 0; indexToCheck < patternIndex; indexToCheck++)
+                            for (int indexToCheck = 0; indexToCheck < queryIndex; indexToCheck++)
                             { // update the index list
                                 indexList.Add(startIndexToVerify + indexToCheck);
                             }
@@ -115,18 +115,22 @@ namespace Wox.Infrastructure
                     lastMatchIndex = index + 1;
                     indexList.Add(index);
 
+                    queryIndex++;
+
                     // increase the pattern matched index and check if everything was matched
-                    if (++patternIndex == currentQueryToCompare.Length)
+                    if (queryIndex == currentSeparatedQueryString.Length)
                     {
-                        if (++currentQueryToCompareIndex >= queryToCompareSeparated.Length)
+                        currentSeparatedQueryStringIndex++;
+
+                        if (currentSeparatedQueryStringIndex >= separatedqueryStrings.Length)
                         { // moved over all the words
                             allMatched = true;
                             break;
                         }
 
                         // otherwise move to the next word
-                        currentQueryToCompare = queryToCompareSeparated[currentQueryToCompareIndex];
-                        patternIndex = 0;
+                        currentSeparatedQueryString = separatedqueryStrings[currentSeparatedQueryStringIndex];
+                        queryIndex = 0;
                         if (!isFullWordMatched)
                         { // if any of the words was not fully matched all are not fully matched
                             allWordsFullyMatched = false;

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -121,7 +121,7 @@ namespace Wox.Infrastructure
                 if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
                 {
                     // if any of the substrings was not matched then consider as all are not matched
-                    allSubstringsContainedInCompareString = !matchFoundInPreviousLoop ? false : allSubstringsContainedInCompareString;
+                    allSubstringsContainedInCompareString = matchFoundInPreviousLoop && allSubstringsContainedInCompareString;
 
                     currentQuerySubstringIndex++;
 

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -41,13 +41,15 @@ namespace Wox.Infrastructure
         }
 
         /// <summary>
-        /// Current method: 
+        /// Current method:
         /// Character matching + substring matching;
-        /// 1. Check query substring's character against full compare string,
-        /// 2. if matched, loop back to verify the previous character.
-        /// 3. If previous character also matches, and is the start of the substring, update list.
-        /// 4. Once the previous character is verified, move on to the next character in the query substring.
-        /// 5. Consider success and move onto scoring if every char or substring without whitespaces matched
+        /// 1. Query search string is split into substrings, separator is whitespace.
+        /// 2. Check each query substring's characters against full compare string,
+        /// 3. if a character in the substring is matched, loop back to verify the previous character.
+        /// 4. If previous character also matches, and is the start of the substring, update list.
+        /// 5. Once the previous character is verified, move on to the next character in the query substring.
+        /// 6. Move onto the next substring's characters until all substrings are checked.
+        /// 7. Consider success and move onto scoring if every char or substring without whitespaces matched
         /// </summary>
         public static MatchResult FuzzySearch(string query, string stringToCompare, MatchOption opt)
         {

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -192,7 +192,7 @@ namespace Wox.Infrastructure
             return currentQuerySubstringIndex >= querySubstringsLength;
         }
 
-        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen, bool allWordsFullyMatched)
+        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen, bool allSubstringsContainedInCompareString)
         {
             // A match found near the beginning of a string is scored more than a match found near the end
             // A match is scored more if the characters in the patterns are closer to each other, 
@@ -209,10 +209,8 @@ namespace Wox.Infrastructure
                 score += 10;
             }
 
-            if (allWordsFullyMatched)
-            {
-                score += 20;
-            }
+            if (allSubstringsContainedInCompareString)
+                score += 10 * string.Concat(query.Where(c => !char.IsWhiteSpace(c))).Count();
 
             return score;
         }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -105,7 +105,7 @@ namespace Wox.Infrastructure
                     {
                         matchFoundInPreviousLoop = true;
 
-                        // if it's the begining character of the first query substring that is matched then we need to update start index
+                        // if it's the beginning character of the first query substring that is matched then we need to update start index
                         firstMatchIndex = currentQuerySubstringIndex == 0 ? startIndexToVerify : firstMatchIndex;
 
                         indexList = GetUpdatedIndexList(startIndexToVerify, currentQuerySubstringCharacterIndex, firstMatchIndexInWord, indexList);

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -147,7 +147,8 @@ namespace Wox.Infrastructure
                 {
                     Success = true,
                     MatchData = indexList,
-                    RawScore = Math.Max(score, pinyinScore)
+                    RawScore = Math.Max(score, pinyinScore),
+                    AllSubstringsContainedInCompareString = allSubstringsContainedInCompareString
                 };
 
                 return result;
@@ -287,6 +288,11 @@ namespace Wox.Infrastructure
                 Score = ApplySearchPrecisionFilter(_rawScore);
             }
         }
+
+        /// <summary>
+        /// Indicates if all query's substrings are contained in the string to compare
+        /// </summary>        
+        public bool AllSubstringsContainedInCompareString { get; set; }
 
         /// <summary>
         /// Matched data to highlight.

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -155,6 +155,38 @@ namespace Wox.Infrastructure
             return new MatchResult { Success = false };
         }
 
+        private static bool AllPreviousCharsMatched(int startIndexToVerify, int currentQuerySubstringCharacterIndex, 
+                                                        string fullStringToCompareWithoutCase, string currentQuerySubstring)
+        {
+            var allMatch = true;
+            for (int indexToCheck = 0; indexToCheck < currentQuerySubstringCharacterIndex; indexToCheck++)
+            {
+                if (fullStringToCompareWithoutCase[startIndexToVerify + indexToCheck] !=
+                    currentQuerySubstring[indexToCheck])
+                {
+                    allMatch = false;
+                }
+            }
+
+            return allMatch;
+        }
+        
+        private static List<int> GetUpdatedIndexList(int startIndexToVerify, int currentQuerySubstringCharacterIndex, int firstMatchIndexInWord, List<int> indexList)
+        {
+            var updatedList = new List<int>();
+
+            indexList.RemoveAll(x => x >= firstMatchIndexInWord);
+
+            updatedList.AddRange(indexList);
+
+            for (int indexToCheck = 0; indexToCheck < currentQuerySubstringCharacterIndex; indexToCheck++)
+            {
+                updatedList.Add(startIndexToVerify + indexToCheck);
+            }
+
+            return updatedList;
+        }
+
         private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen,
             bool isFullyContained, bool allWordsFullyMatched)
         {

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -120,6 +120,9 @@ namespace Wox.Infrastructure
                 // if finished looping through every character in the current substring
                 if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
                 {
+                    // if any of the substrings was not matched then consider as all are not matched
+                    allSubstringsContainedInCompareString = !matchFoundInPreviousLoop ? false : allSubstringsContainedInCompareString;
+
                     currentQuerySubstringIndex++;
 
                     allQuerySubstringsMatched = AllQuerySubstringsMatched(currentQuerySubstringIndex, querySubstrings.Length);
@@ -129,9 +132,6 @@ namespace Wox.Infrastructure
                     // otherwise move to the next query substring
                     currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
                     currentQuerySubstringCharacterIndex = 0;
-
-                    // if any of the substrings was not matched then consider as all are not matched
-                    allSubstringsContainedInCompareString = !matchFoundInPreviousLoop ? false : allSubstringsContainedInCompareString;
                 }
             }
             

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -138,9 +138,7 @@ namespace Wox.Infrastructure
             // proceed to calculate score if every char or substring without whitespaces matched
             if (allQuerySubstringsMatched)
             {
-                // check if all query substrings were contained in the string to compare
-                bool containedFully = lastMatchIndex - firstMatchIndex == queryWithoutCase.Length;
-                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, containedFully, allSubstringsContainedInCompareString);
+                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
                 var pinyinScore = ScoreForPinyin(stringToCompare, query);
 
                 var result = new MatchResult
@@ -194,8 +192,7 @@ namespace Wox.Infrastructure
             return currentQuerySubstringIndex >= querySubstringsLength;
         }
 
-        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen,
-            bool isFullyContained, bool allWordsFullyMatched)
+        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen, bool allWordsFullyMatched)
         {
             // A match found near the beginning of a string is scored more than a match found near the end
             // A match is scored more if the characters in the patterns are closer to each other, 
@@ -210,11 +207,6 @@ namespace Wox.Infrastructure
             else if (stringToCompare.Length - query.Length < 10)
             {
                 score += 10;
-            }
-
-            if (isFullyContained)
-            {
-                score += 20; // honestly I'm not sure what would be a good number here or should it factor the size of the pattern
             }
 
             if (allWordsFullyMatched)

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -210,7 +210,11 @@ namespace Wox.Infrastructure
             }
 
             if (allSubstringsContainedInCompareString)
-                score += 10 * string.Concat(query.Where(c => !char.IsWhiteSpace(c))).Count();
+            {
+                int count = query.Count(c => !char.IsWhiteSpace(c));
+                int factor = count < 4 ? 10 : 5;
+                score += factor * count;
+            }
 
             return score;
         }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -145,8 +145,7 @@ namespace Wox.Infrastructure
                 {
                     Success = true,
                     MatchData = indexList,
-                    RawScore = Math.Max(score, pinyinScore),
-                    AllSubstringsContainedInCompareString = allSubstringsContainedInCompareString
+                    RawScore = Math.Max(score, pinyinScore)
                 };
 
                 return result;
@@ -282,11 +281,6 @@ namespace Wox.Infrastructure
                 Score = ApplySearchPrecisionFilter(_rawScore);
             }
         }
-
-        /// <summary>
-        /// Indicates if all query's substrings are contained in the string to compare
-        /// </summary>        
-        public bool AllSubstringsContainedInCompareString { get; set; }
 
         /// <summary>
         /// Matched data to highlight.

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -109,34 +109,28 @@ namespace Wox.Infrastructure
 
                 currentQuerySubstringCharacterIndex++;
 
-                // if finished looping through every character in the substring
+                // if finished looping through every character in the current substring
                 if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
                 {
                     currentQuerySubstringIndex++;
 
-                    // if all query substrings are matched
-                    if (currentQuerySubstringIndex >= querySubstrings.Length)
-                    {
-                        allQuerySubstringsMatched = true;
+                    allQuerySubstringsMatched = AllQuerySubstringsMatched(currentQuerySubstringIndex, querySubstrings.Length);
+                    if (allQuerySubstringsMatched)
                         break;
-                    }
 
                     // otherwise move to the next query substring
                     currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
                     currentQuerySubstringCharacterIndex = 0;
 
-                    if (!matchFoundInPreviousLoop)
-                    {
-                        // if any of the words was not fully matched all are not fully matched
-                        allWordsFullyMatched = false;
-                    }
+                    // if any of the substrings was not matched then consider as all are not matched
+                    allWordsFullyMatched = !matchFoundInPreviousLoop ? false : allWordsFullyMatched;
                 }
             }
             
             // return rendered string if we have a match for every char or all substring without whitespaces matched
             if (allQuerySubstringsMatched)
             {
-                // check if all query string was contained in string to compare
+                // check if all query substrings were contained in the string to compare
                 bool containedFully = lastMatchIndex - firstMatchIndex == queryWithoutCase.Length;
                 var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, containedFully, allWordsFullyMatched);
                 var pinyinScore = ScoreForPinyin(stringToCompare, query);
@@ -184,6 +178,11 @@ namespace Wox.Infrastructure
             }
 
             return updatedList;
+        }
+
+        private static bool AllQuerySubstringsMatched(int currentQuerySubstringIndex, int querySubstringsLength)
+        {
+            return currentQuerySubstringIndex >= querySubstringsLength;
         }
 
         private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen,

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -61,7 +61,7 @@ namespace Wox.Infrastructure
 
             var queryWithoutCase = opt.IgnoreCase ? query.ToLower() : query;
                         
-            var querySubstrings = queryWithoutCase.Split(' ');
+            var querySubstrings = queryWithoutCase.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             int currentQuerySubstringIndex = 0;
             var currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
             var currentQuerySubstringCharacterIndex = 0;

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -41,7 +41,13 @@ namespace Wox.Infrastructure
         }
 
         /// <summary>
-        /// refer to https://github.com/mattyork/fuzzy
+        /// Current method: 
+        /// Character matching + substring matching;
+        /// 1. Check query substring's character against full compare string,
+        /// 2. if matched, loop back to verify the previous character.
+        /// 3. If previous character also matches, and is the start of the substring, update list.
+        /// 4. Once the previous character is verified, move on to the next character in the query substring.
+        /// 5. Consider success and move onto scoring if every char or substring without whitespaces matched
         /// </summary>
         public static MatchResult FuzzySearch(string query, string stringToCompare, MatchOption opt)
         {
@@ -127,7 +133,7 @@ namespace Wox.Infrastructure
                 }
             }
             
-            // return rendered string if we have a match for every char or all substring without whitespaces matched
+            // return rendered string if every char or substring without whitespaces matched
             if (allQuerySubstringsMatched)
             {
                 // check if all query substrings were contained in the string to compare

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -12,7 +12,7 @@ namespace Wox.Infrastructure
     {
         public static MatchOption DefaultMatchOption = new MatchOption();
 
-        public static int UserSettingSearchPrecision { get; set; }
+        public static SearchPrecisionScore UserSettingSearchPrecision { get; set; }
 
         public static bool ShouldUsePinyin { get; set; }
 
@@ -296,7 +296,7 @@ namespace Wox.Infrastructure
 
         private bool IsSearchPrecisionScoreMet(int score)
         {
-            return score >= UserSettingSearchPrecision;
+            return score >= (int)UserSettingSearchPrecision;
         }
 
         private int ApplySearchPrecisionFilter(int score)

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -69,68 +69,67 @@ namespace Wox.Infrastructure
 
             for (var compareStringIndex = 0; compareStringIndex < fullStringToCompareWithoutCase.Length; compareStringIndex++)
             {
-                if (fullStringToCompareWithoutCase[compareStringIndex] == currentQuerySubstring[currentQuerySubstringCharacterIndex])
-                {
-                    if (firstMatchIndex < 0)
-                    {
-                        // first matched char will become the start of the compared string
-                        firstMatchIndex = compareStringIndex;
-                    }
-
-                    if (currentQuerySubstringCharacterIndex == 0)
-                    {
-                        // first letter of current word
-                        matchFoundInPreviousLoop = true;
-                        firstMatchIndexInWord = compareStringIndex;
-                    }
-                    else if (!matchFoundInPreviousLoop)
-                    {
-                        // we want to verify that there is not a better match if this is not a full word
-                        // in order to do so we need to verify all previous chars are part of the pattern
-                        var startIndexToVerify = compareStringIndex - currentQuerySubstringCharacterIndex;
-
-                        if (AllPreviousCharsMatched(startIndexToVerify, currentQuerySubstringCharacterIndex, fullStringToCompareWithoutCase, currentQuerySubstring))
-                        {
-                            matchFoundInPreviousLoop = true;
-
-                            // if it's the begining character of the first query substring that is matched then we need to update start index
-                            firstMatchIndex = currentQuerySubstringIndex == 0 ? startIndexToVerify : firstMatchIndex;
-
-                            indexList = GetUpdatedIndexList(startIndexToVerify, currentQuerySubstringCharacterIndex, firstMatchIndexInWord, indexList);
-                        }
-                    }
-
-                    lastMatchIndex = compareStringIndex + 1;
-                    indexList.Add(compareStringIndex);
-
-                    currentQuerySubstringCharacterIndex++;
-
-                    // if finished looping through every character in the substring
-                    if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
-                    {
-                        currentQuerySubstringIndex++;
-
-                        // if all query substrings are matched
-                        if (currentQuerySubstringIndex >= querySubstrings.Length)
-                        {
-                            allQuerySubstringsMatched = true;
-                            break;
-                        }
-
-                        // otherwise move to the next query substring
-                        currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
-                        currentQuerySubstringCharacterIndex = 0;
-
-                        if (!matchFoundInPreviousLoop)
-                        {
-                            // if any of the words was not fully matched all are not fully matched
-                            allWordsFullyMatched = false;
-                        }
-                    }
-                }
-                else
+                if (fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex])
                 {
                     matchFoundInPreviousLoop = false;
+                    continue;
+                }
+
+                if (firstMatchIndex < 0)
+                {
+                    // first matched char will become the start of the compared string
+                    firstMatchIndex = compareStringIndex;
+                }
+
+                if (currentQuerySubstringCharacterIndex == 0)
+                {
+                    // first letter of current word
+                    matchFoundInPreviousLoop = true;
+                    firstMatchIndexInWord = compareStringIndex;
+                }
+                else if (!matchFoundInPreviousLoop)
+                {
+                    // we want to verify that there is not a better match if this is not a full word
+                    // in order to do so we need to verify all previous chars are part of the pattern
+                    var startIndexToVerify = compareStringIndex - currentQuerySubstringCharacterIndex;
+
+                    if (AllPreviousCharsMatched(startIndexToVerify, currentQuerySubstringCharacterIndex, fullStringToCompareWithoutCase, currentQuerySubstring))
+                    {
+                        matchFoundInPreviousLoop = true;
+
+                        // if it's the begining character of the first query substring that is matched then we need to update start index
+                        firstMatchIndex = currentQuerySubstringIndex == 0 ? startIndexToVerify : firstMatchIndex;
+
+                        indexList = GetUpdatedIndexList(startIndexToVerify, currentQuerySubstringCharacterIndex, firstMatchIndexInWord, indexList);
+                    }
+                }
+
+                lastMatchIndex = compareStringIndex + 1;
+                indexList.Add(compareStringIndex);
+
+                currentQuerySubstringCharacterIndex++;
+
+                // if finished looping through every character in the substring
+                if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
+                {
+                    currentQuerySubstringIndex++;
+
+                    // if all query substrings are matched
+                    if (currentQuerySubstringIndex >= querySubstrings.Length)
+                    {
+                        allQuerySubstringsMatched = true;
+                        break;
+                    }
+
+                    // otherwise move to the next query substring
+                    currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
+                    currentQuerySubstringCharacterIndex = 0;
+
+                    if (!matchFoundInPreviousLoop)
+                    {
+                        // if any of the words was not fully matched all are not fully matched
+                        allWordsFullyMatched = false;
+                    }
                 }
             }
             

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -133,7 +133,7 @@ namespace Wox.Infrastructure
                 }
             }
             
-            // return rendered string if every char or substring without whitespaces matched
+            // proceed to calculate score if every char or substring without whitespaces matched
             if (allQuerySubstringsMatched)
             {
                 // check if all query substrings were contained in the string to compare

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -71,7 +71,7 @@ namespace Wox.Infrastructure
             var lastMatchIndex = 0;
             bool allQuerySubstringsMatched = false;
             bool matchFoundInPreviousLoop = false;
-            bool allWordsFullyMatched = true;
+            bool allSubstringsContainedInCompareString = true;
 
             var indexList = new List<int>();
 
@@ -131,7 +131,7 @@ namespace Wox.Infrastructure
                     currentQuerySubstringCharacterIndex = 0;
 
                     // if any of the substrings was not matched then consider as all are not matched
-                    allWordsFullyMatched = !matchFoundInPreviousLoop ? false : allWordsFullyMatched;
+                    allSubstringsContainedInCompareString = !matchFoundInPreviousLoop ? false : allSubstringsContainedInCompareString;
                 }
             }
             
@@ -140,7 +140,7 @@ namespace Wox.Infrastructure
             {
                 // check if all query substrings were contained in the string to compare
                 bool containedFully = lastMatchIndex - firstMatchIndex == queryWithoutCase.Length;
-                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, containedFully, allWordsFullyMatched);
+                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, containedFully, allSubstringsContainedInCompareString);
                 var pinyinScore = ScoreForPinyin(stringToCompare, query);
 
                 var result = new MatchResult

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -36,14 +36,27 @@ namespace Wox.Infrastructure.UserSettings
         }
 
 
-        private string _querySearchPrecision { get; set; } = StringMatcher.SearchPrecisionScore.Regular.ToString();
-        public string QuerySearchPrecision
+        internal StringMatcher.SearchPrecisionScore QuerySearchPrecision { get; private set; } = StringMatcher.SearchPrecisionScore.Regular;
+
+        public string QuerySearchPrecisionString
         {
-            get { return _querySearchPrecision; }
+            get { return QuerySearchPrecision.ToString(); }
             set
             {
-                _querySearchPrecision = value;
-                StringMatcher.UserSettingSearchPrecision = value;
+                try
+                {
+                    var precisionScore = (StringMatcher.SearchPrecisionScore)Enum.Parse(
+                        typeof(StringMatcher.SearchPrecisionScore),
+                        value);
+                    QuerySearchPrecision = precisionScore;
+                    StringMatcher.UserSettingSearchPrecision = (int)precisionScore;
+                }
+                catch (System.Exception e)
+                {
+                    // what do we do here?!
+                    Logger.Log.Exception(nameof(Settings), "Fail to set QuerySearchPrecision", e);
+                    throw;
+                }
             }
         }
 

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -45,16 +45,19 @@ namespace Wox.Infrastructure.UserSettings
             {
                 try
                 {
-                    var precisionScore = (StringMatcher.SearchPrecisionScore)Enum.Parse(
-                        typeof(StringMatcher.SearchPrecisionScore),
-                        value);
+                    var precisionScore = (StringMatcher.SearchPrecisionScore)Enum
+                                            .Parse(typeof(StringMatcher.SearchPrecisionScore), value);
+
                     QuerySearchPrecision = precisionScore;
-                    StringMatcher.UserSettingSearchPrecision = (int)precisionScore;
+                    StringMatcher.UserSettingSearchPrecision = precisionScore;
                 }
-                catch (System.Exception e)
+                catch (ArgumentException e)
                 {
-                    // what do we do here?!
-                    Logger.Log.Exception(nameof(Settings), "Fail to set QuerySearchPrecision", e);
+                    Logger.Log.Exception(nameof(Settings), "Failed to load QuerySearchPrecisionString value from Settings file", e);
+
+                    QuerySearchPrecision = StringMatcher.SearchPrecisionScore.Regular;
+                    StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.Regular;
+
                     throw;
                 }
             }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -122,50 +122,20 @@ namespace Wox.Test
             }
         }
 
-        [TestCase]
-        public void WhenGivenStringsForCalScoreMethodThenShouldReturnCurrentScoring()
+        [TestCase(Chrome, Chrome, 167)]
+        [TestCase(Chrome, LastIsChrome, 113)]
+        [TestCase(Chrome, HelpCureHopeRaiseOnMindEntityChrome, 21)]
+        [TestCase(Chrome, UninstallOrChangeProgramsOnYourComputer, 15)]
+        [TestCase(Chrome, CandyCrushSagaFromKing, 0)]
+        [TestCase("sql", MicrosoftSqlServerManagementStudio, 56)]
+        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 119)]//double spacing intended
+        public void WhenGivenQueryStringThenShouldReturnCurrentScoring(string queryString, string compareString, int expectedScore)
         {
-            // Arrange
-            string searchTerm = "chrome"; // since this looks for specific results it will always be one case
-            var searchStrings = new List<string>
-            {
-                Chrome,//SCORE: 107
-                LastIsChrome,//SCORE: 53
-                HelpCureHopeRaiseOnMindEntityChrome,//SCORE: 21
-                UninstallOrChangeProgramsOnYourComputer, //SCORE: 15
-                CandyCrushSagaFromKing//SCORE: 0
-            }
-            .OrderByDescending(x => x)
-            .ToList();
+            // When, Given
+            var rawScore = StringMatcher.FuzzySearch(queryString, compareString).RawScore;
 
-            // Act
-            var results = new List<Result>();
-            foreach (var str in searchStrings)
-            {
-                results.Add(new Result
-                {
-                    Title = str,
-                    Score = StringMatcher.FuzzySearch(searchTerm, str).RawScore
-                });
-            }
-
-            // Assert
-            VerifyResult(147, Chrome);
-            VerifyResult(93, LastIsChrome);
-            VerifyResult(41, HelpCureHopeRaiseOnMindEntityChrome);
-            VerifyResult(35, UninstallOrChangeProgramsOnYourComputer);
-            VerifyResult(0, CandyCrushSagaFromKing);
-
-            void VerifyResult(int expectedScore, string expectedTitle)
-            {
-                var result = results.FirstOrDefault(x => x.Title == expectedTitle);
-                if (result == null)
-                {
-                    Assert.Fail($"Fail to find result: {expectedTitle} in result list");
-                }
-
-                Assert.AreEqual(expectedScore, result.Score, $"Expected score for {expectedTitle}: {expectedScore}, Actual: {result.Score}");
-            }
+            // Should
+            Assert.AreEqual(expectedScore, rawScore, $"Expected score for compare string '{compareString}': {expectedScore}, Actual: {rawScore}");
         }
 
         [TestCase("goo", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
@@ -184,26 +154,25 @@ namespace Wox.Test
             int expectedPrecisionScore,
             bool expectedPrecisionResult)
         {
-            // Arrange
-            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;
-            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore; // this is why static state is evil...
+            // When            
+            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore;
 
-            // Act
+            // Given
             var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
             Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
-            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore} ({expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
 
-            // Assert
+            // Should
             Assert.AreEqual(expectedPrecisionResult, matchResult.IsSearchPrecisionScoreMet(),
                 $"Query:{queryString}{Environment.NewLine} " +
                 $"Compare:{compareString}{Environment.NewLine}" +
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
-                $"Precision Level: {expectedPrecisionString}={expectedPrecisionScore}");
+                $"Precision Level: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore}={expectedPrecisionScore}");
         }
 
         [TestCase("exce", "OverLeaf-Latex: An online LaTeX editor", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
@@ -226,26 +195,25 @@ namespace Wox.Test
             int expectedPrecisionScore,
             bool expectedPrecisionResult)
         {
-            // Arrange
-            var expectedPrecisionString = (StringMatcher.SearchPrecisionScore)expectedPrecisionScore;
-            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore; // this is why static state is evil...
+            // When
+            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore;
 
-            // Act
+            // Given
             var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
             Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
-            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore} ({expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
 
-            // Assert
+            // Should
             Assert.AreEqual(expectedPrecisionResult, matchResult.IsSearchPrecisionScoreMet(),
                 $"Query:{queryString}{Environment.NewLine} " +
                 $"Compare:{compareString}{Environment.NewLine}" +
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
-                $"Precision Level: {expectedPrecisionString}={expectedPrecisionScore}");
+                $"Precision Level: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore}={expectedPrecisionScore}");
         }
 
         [TestCase("sql servman", MicrosoftSqlServerManagementStudio, false)]

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -191,6 +191,13 @@ namespace Wox.Test
             // Act
             var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
 
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
+
             // Assert
             Assert.AreEqual(expectedPrecisionResult, matchResult.IsSearchPrecisionScoreMet(),
                 $"Query:{queryString}{Environment.NewLine} " +
@@ -224,6 +231,13 @@ namespace Wox.Test
 
             // Act
             var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
+
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionString} ({expectedPrecisionScore})");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
 
             // Assert
             Assert.AreEqual(expectedPrecisionResult, matchResult.IsSearchPrecisionScoreMet(),

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -182,10 +182,15 @@ namespace Wox.Test
         [TestCase("sql manag", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql serv", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sqlserv", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql servman", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql serv man", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql studio", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("mic", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("chr", "Shutdown", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("mssms", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, false)]
         [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("ch r", "Change settings for text-to-speech and for speech recognition (if installed).", StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("a test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
         public void WhenGivenQueryShouldReturnResultsContainingAllQuerySubstrings(
@@ -213,22 +218,6 @@ namespace Wox.Test
                 $"Compare:{compareString}{Environment.NewLine}" +
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
                 $"Precision Score: {(int)expectedPrecisionScore}");
-        }
-
-        [TestCase("sql servman", MicrosoftSqlServerManagementStudio, false)]
-        [TestCase("sql serv man", MicrosoftSqlServerManagementStudio, true)]
-        [TestCase("sql", MicrosoftSqlServerManagementStudio, true)]
-        [TestCase("sqlserv", MicrosoftSqlServerManagementStudio, false)]
-        [TestCase("mssms", MicrosoftSqlServerManagementStudio, false)]
-        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", false)]
-        [TestCase("ch r", "Change settings for text-to-speech and for speech recognition (if installed).", true)]
-        public void WhenGivenQueryShouldEvaluateTrueFalseIfCompareStringContainsAllSubstrings(string queryString, string compareString, bool expectedResult)
-        {
-            // When, Given
-            var matchResult = StringMatcher.FuzzySearch(queryString, compareString).AllSubstringsContainedInCompareString;
-
-            // Should
-            Assert.AreEqual(matchResult, expectedResult);
         }
     }
 }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -121,13 +121,13 @@ namespace Wox.Test
             }
         }
 
-        [TestCase(Chrome, Chrome, 167)]
-        [TestCase(Chrome, LastIsChrome, 113)]
+        [TestCase(Chrome, Chrome, 137)]
+        [TestCase(Chrome, LastIsChrome, 83)]
         [TestCase(Chrome, HelpCureHopeRaiseOnMindEntityChrome, 21)]
         [TestCase(Chrome, UninstallOrChangeProgramsOnYourComputer, 15)]
         [TestCase(Chrome, CandyCrushSagaFromKing, 0)]
         [TestCase("sql", MicrosoftSqlServerManagementStudio, 56)]
-        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 119)]//double spacing intended
+        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 79)]//double spacing intended
         public void WhenGivenQueryStringThenShouldReturnCurrentScoring(string queryString, string compareString, int expectedScore)
         {
             // When, Given

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -214,6 +214,7 @@ namespace Wox.Test
         [TestCase("sql manag", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("sql serv", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql studio", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("mic", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("chr", "Shutdown", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
         [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", (int)StringMatcher.SearchPrecisionScore.Regular, false)]

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -247,5 +247,21 @@ namespace Wox.Test
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
                 $"Precision Level: {expectedPrecisionString}={expectedPrecisionScore}");
         }
+
+        [TestCase("sql servman", MicrosoftSqlServerManagementStudio, false)]
+        [TestCase("sql serv man", MicrosoftSqlServerManagementStudio, true)]
+        [TestCase("sql", MicrosoftSqlServerManagementStudio, true)]
+        [TestCase("sqlserv", MicrosoftSqlServerManagementStudio, false)]
+        [TestCase("mssms", MicrosoftSqlServerManagementStudio, false)]
+        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", false)]
+        [TestCase("ch r", "Change settings for text-to-speech and for speech recognition (if installed).", true)]
+        public void WhenGivenQueryShouldEvaluateTrueFalseIfCompareStringContainsAllSubstrings(string queryString, string compareString, bool expectedResult)
+        {
+            // When, Given
+            var matchResult = StringMatcher.FuzzySearch(queryString, compareString).AllSubstringsContainedInCompareString;
+
+            // Should
+            Assert.AreEqual(matchResult, expectedResult);
+        }
     }
 }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using Wox.Infrastructure;
-using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
 
 namespace Wox.Test
@@ -138,20 +137,20 @@ namespace Wox.Test
             Assert.AreEqual(expectedScore, rawScore, $"Expected score for compare string '{compareString}': {expectedScore}, Actual: {rawScore}");
         }
 
-        [TestCase("goo", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("chr", "Google Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
-        [TestCase("chr", "Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("chr", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Low, true)]
-        [TestCase("chr", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("chr", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.None, true)]
-        [TestCase("ccs", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Low, true)]
-        [TestCase("cand", "Candy Crush Saga from King", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("cand", "Help cure hope raise on mind entity Chrome", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("goo", "Google Chrome", StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Google Chrome", StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("chr", "Chrome", StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Help cure hope raise on mind entity Chrome", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Help cure hope raise on mind entity Chrome", StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("chr", "Candy Crush Saga from King", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Candy Crush Saga from King", StringMatcher.SearchPrecisionScore.None, true)]
+        [TestCase("ccs", "Candy Crush Saga from King", StringMatcher.SearchPrecisionScore.Low, true)]
+        [TestCase("cand", "Candy Crush Saga from King",StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("cand", "Help cure hope raise on mind entity Chrome", StringMatcher.SearchPrecisionScore.Regular, false)]
         public void WhenGivenDesiredPrecisionThenShouldReturnAllResultsGreaterOrEqual(
             string queryString,
             string compareString,
-            int expectedPrecisionScore,
+            StringMatcher.SearchPrecisionScore expectedPrecisionScore,
             bool expectedPrecisionResult)
         {
             // When            
@@ -163,7 +162,7 @@ namespace Wox.Test
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
             Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
-            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore} ({expectedPrecisionScore})");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionScore} ({(int)expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
 
@@ -172,27 +171,27 @@ namespace Wox.Test
                 $"Query:{queryString}{Environment.NewLine} " +
                 $"Compare:{compareString}{Environment.NewLine}" +
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
-                $"Precision Level: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore}={expectedPrecisionScore}");
+                $"Precision Score: {(int)expectedPrecisionScore}");
         }
 
-        [TestCase("exce", "OverLeaf-Latex: An online LaTeX editor", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("term", "Windows Terminal (Preview)", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("sql s managa", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("sql' s manag", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("sql s manag", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("sql manag", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("sql", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("sql serv", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("sql studio", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("mic", MicrosoftSqlServerManagementStudio, (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("chr", "Shutdown", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", (int)StringMatcher.SearchPrecisionScore.Regular, false)]
-        [TestCase("a test", "This is a test", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
-        [TestCase("test", "This is a test", (int)StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("exce", "OverLeaf-Latex: An online LaTeX editor", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("term", "Windows Terminal (Preview)", StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql s managa", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql' s manag", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("sql s manag", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql manag", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql serv", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("sql studio", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("mic", MicrosoftSqlServerManagementStudio, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("chr", "Shutdown", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("chr", "Change settings for text-to-speech and for speech recognition (if installed).", StringMatcher.SearchPrecisionScore.Regular, false)]
+        [TestCase("a test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
         public void WhenGivenQueryShouldReturnResultsContainingAllQuerySubstrings(
             string queryString,
             string compareString,
-            int expectedPrecisionScore,
+            StringMatcher.SearchPrecisionScore expectedPrecisionScore,
             bool expectedPrecisionResult)
         {
             // When
@@ -204,7 +203,7 @@ namespace Wox.Test
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
             Debug.WriteLine($"QueryString: {queryString}     CompareString: {compareString}");
-            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore} ({expectedPrecisionScore})");
+            Debug.WriteLine($"RAW SCORE: {matchResult.RawScore.ToString()}, PrecisionLevelSetAt: {expectedPrecisionScore} ({(int)expectedPrecisionScore})");
             Debug.WriteLine("###############################################");
             Debug.WriteLine("");
 
@@ -213,7 +212,7 @@ namespace Wox.Test
                 $"Query:{queryString}{Environment.NewLine} " +
                 $"Compare:{compareString}{Environment.NewLine}" +
                 $"Raw Score: {matchResult.RawScore}{Environment.NewLine}" +
-                $"Precision Level: {(StringMatcher.SearchPrecisionScore)expectedPrecisionScore}={expectedPrecisionScore}");
+                $"Precision Score: {(int)expectedPrecisionScore}");
         }
 
         [TestCase("sql servman", MicrosoftSqlServerManagementStudio, false)]

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -55,7 +55,7 @@ namespace Wox
 
                 Alphabet.Initialize(_settings);
 
-                StringMatcher.UserSettingSearchPrecision = (int)_settings.QuerySearchPrecision;
+                StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
                 StringMatcher.ShouldUsePinyin = _settings.ShouldUsePinyin;
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -55,7 +55,7 @@ namespace Wox
 
                 Alphabet.Initialize(_settings);
 
-                StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
+                StringMatcher.UserSettingSearchPrecision = (int)_settings.QuerySearchPrecision;
                 StringMatcher.ShouldUsePinyin = _settings.ShouldUsePinyin;
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -62,7 +62,7 @@
                     <TextBlock Text="{DynamicResource querySearchPrecision}" />
                     <ComboBox Margin="10 0 0 0" Width="120"
                               ItemsSource="{Binding QuerySearchPrecisionStrings}" 
-                              SelectedItem="{Binding Settings.QuerySearchPrecision}" />
+                              SelectedItem="{Binding Settings.QuerySearchPrecisionString}" />
                 </StackPanel>
                 <StackPanel Margin="10" Orientation="Horizontal">
                     <TextBlock Text="{DynamicResource lastQueryMode}" />

--- a/Wox/ViewModel/SettingWindowViewModel.cs
+++ b/Wox/ViewModel/SettingWindowViewModel.cs
@@ -73,7 +73,7 @@ namespace Wox.ViewModel
         public List<string> QuerySearchPrecisionStrings
         {
             get
-            { 
+            {
                 var precisionStrings = new List<string>();
 
                 var enumList = Enum.GetValues(typeof(StringMatcher.SearchPrecisionScore)).Cast<StringMatcher.SearchPrecisionScore>().ToList();


### PR DESCRIPTION
Problem context:

1. Wox's search mechanism uses character matching- in a given query string "sql" matching with program title compare string "Microsoft SQL Management Studio" scenario, the match fails for 'Regular' search precision level. This is due to 'RawScore' obtain as 26, not enough to make the Score required for 'Regular' search precision level of 50.

2. Searching for results that may contain partial words such as "term" should return "Windows Terminal' without having to type in "Windows Te".

Just an overall more natural search experience while retaining the capability of using character search as well.

Fixes issues #84  & #92 

Changes:
 - Remove String Builder as it now has no use.
 - Updated SearchPrecisionScore property + in Settings class conversion from string to SearchPrecisionScore.
 - Updated some logging
 - Updated stringmatcher: 
  - Added flags that the method will find:.
      - allSubstringsContainedInCompareString: If all query's sub-strings are contained in the string to compare.
      - Added the ability to fix a word location if found contained fully, for example:
           □ Query: sql
           □ String to compare: server sql mg
           □ In old alg:
               Start index = 0, "server sql" and matched indexs are = 0,8,9
           □ In new alg: it will see that the second sql is better match and result would have a full substring as follows:
               Start index = 7, "sql" and matched indexes are = 7,8,9