### PR TITLE
Folder plugin updates to searching and sorting of results

### DIFF
--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -195,7 +195,10 @@ namespace Wox.Plugin.Folder
                 // match everything before and after search term using supported wildcard '*', ie. *searchterm*
                 incompleteName = "*" + incompleteName.Substring(1);
             }
-            
+
+            var folderList = new List<Result>();
+            var fileList = new List<Result>();
+
             try
             {
                 // search folder and add results
@@ -206,11 +209,14 @@ namespace Wox.Plugin.Folder
                 {
                     if ((fileSystemInfo.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden) continue;
 
-                    var result =
-                        fileSystemInfo is DirectoryInfo
-                            ? CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName, query)
-                            : CreateFileResult(fileSystemInfo.FullName, query);
-                    results.Add(result);
+                    if(fileSystemInfo is DirectoryInfo)
+                    {
+                        folderList.Add(CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName, query));
+                    }
+                    else
+                    {
+                        fileList.Add(CreateFileResult(fileSystemInfo.FullName, query));
+                    }
                 }
             }
             catch (Exception e)
@@ -225,7 +231,8 @@ namespace Wox.Plugin.Folder
                 throw;
             }
 
-            return results;
+            // Intial ordering, this order can be updated later by UpdateResultView.MainViewModel based on history of user selection.
+            return results.Concat(folderList.OrderBy(x => x.Title)).Concat(fileList.OrderBy(x => x.Title)).ToList();
         }
 
         private static Result CreateFileResult(string filePath, Query query)

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -191,7 +191,9 @@ namespace Wox.Plugin.Folder
             if (incompleteName.StartsWith(">"))
             {
                 searchOption = SearchOption.AllDirectories;
-                incompleteName = incompleteName.Substring(1);
+
+                // match everything before and after search term using supported wildcard '*', ie. *searchterm*
+                incompleteName = "*" + incompleteName.Substring(1);
             }
             
             try


### PR DESCRIPTION
- Update search to using wild card before and after search term. So looking for result VirtualMachine Image will be retrieved either by Image or VirtualMachine. (Current search can only find with VirtualMachine due to wildcard at the end of search term: searchterm*)

- Updated result sorting by placing folder before files, like Windows Explorer, and then order ascending by title. This order will likely change slightly due to sorting that happen later by giving preference to results that match user selection history.