### PR TITLE
Fix pinyin fuzzysearch

### DIFF
--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -41,7 +41,7 @@ namespace Wox.Infrastructure
 
         public static Func<string, string> GetLanguageConverter()
         {
-            if (_settings.ShouldUsePinyin)
+            if (_settings?.ShouldUsePinyin != null && _settings.ShouldUsePinyin)
                 return ConvertChineseCharactersToPinyin;
 
             return null;

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using hyjiacan.util.p4n;
 using hyjiacan.util.p4n.format;
 using Wox.Infrastructure.Logger;
@@ -36,6 +37,37 @@ namespace Wox.Infrastructure
                 PinyinHelper.toHanyuPinyinStringArray('T', Format);
             });
             Log.Info($"|Wox.Infrastructure.Alphabet.Initialize|Number of preload pinyin combination<{PinyinCache.Count}>");
+        }
+
+        public static Func<string, string> GetLanguageConverter()
+        {
+            if (_settings.ShouldUsePinyin)
+                return ConvertChineseCharactersToPinyin;
+
+            return null;
+        }
+
+        public static string ConvertChineseCharactersToPinyin(string source)
+        {
+            if (!_settings.ShouldUsePinyin)
+                return source;
+
+            if (string.IsNullOrEmpty(source))
+                return source;
+
+            if (!Alphabet.ContainsChinese(source))
+                return source;
+                
+            var combination = Alphabet.PinyinCombination(source);
+            
+            var pinyinArray=combination.Select(x => string.Join("", x));
+            var acronymArray = combination.Select(Alphabet.Acronym).Distinct();
+
+            var all = acronymArray.Concat(pinyinArray);
+            var joinedSingleStringCombination = new StringBuilder(" ");
+            all.ToList().ForEach(x => joinedSingleStringCombination.Append(x));
+
+            return joinedSingleStringCombination.ToString();
         }
 
         public static void Save()

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -50,6 +50,7 @@ namespace Wox.Infrastructure
         private static string[] EmptyStringArray = new string[0];
         private static string[][] Empty2DStringArray = new string[0][];
 
+        [Obsolete("Not accurate, eg 音乐 will not return yinyue but returns yinle ")]
         /// <summary>
         /// replace chinese character with pinyin, non chinese character won't be modified
         /// <param name="word"> should be word or sentence, instead of single character. e.g. 微软 </param>

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -55,16 +55,16 @@ namespace Wox.Infrastructure
             if (string.IsNullOrEmpty(source))
                 return source;
 
-            if (!Alphabet.ContainsChinese(source))
+            if (!ContainsChinese(source))
                 return source;
                 
-            var combination = Alphabet.PinyinCombination(source);
+            var combination = PinyinCombination(source);
             
             var pinyinArray=combination.Select(x => string.Join("", x));
-            var acronymArray = combination.Select(Alphabet.Acronym).Distinct();
+            var acronymArray = combination.Select(Acronym).Distinct();
 
+            var joinedSingleStringCombination = new StringBuilder();
             var all = acronymArray.Concat(pinyinArray);
-            var joinedSingleStringCombination = new StringBuilder(" ");
             all.ToList().ForEach(x => joinedSingleStringCombination.Append(x));
 
             return joinedSingleStringCombination.ToString();

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,7 +76,7 @@ namespace Wox.Infrastructure
         /// e.g. 音乐 will return yinyue and yinle
         /// <param name="characters"> should be word or sentence, instead of single character. e.g. 微软 </param>
         /// </summmary>
-        public static string[][] PinyinComination(string characters)
+        public static string[][] PinyinCombination(string characters)
         {
             if (!_settings.ShouldUsePinyin || string.IsNullOrEmpty(characters))
             {

--- a/Wox.Infrastructure/FuzzyMatcher.cs
+++ b/Wox.Infrastructure/FuzzyMatcher.cs
@@ -16,7 +16,7 @@ namespace Wox.Infrastructure
 
         public static FuzzyMatcher Create(string query)
         {
-            return new FuzzyMatcher(query, StringMatcher.DefaultMatchOption);
+            return new FuzzyMatcher(query, new MatchOption());
         }
 
         public static FuzzyMatcher Create(string query, MatchOption opt)
@@ -26,7 +26,7 @@ namespace Wox.Infrastructure
 
         public MatchResult Evaluate(string str)
         {
-            return StringMatcher.FuzzySearch(query, str, opt);
+            return StringMatcher.Instance.FuzzyMatch(query, str, opt);
         }
     }
 }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -238,12 +238,12 @@ namespace Wox.Infrastructure
             SearchPrecision = searchPrecision;
         }
 
-        public MatchResult(bool success, SearchPrecisionScore searchPrecision, List<int> matchData, int score)
+        public MatchResult(bool success, SearchPrecisionScore searchPrecision, List<int> matchData, int rawScore)
         {
             Success = success;
             SearchPrecision = searchPrecision;
             MatchData = matchData;
-            Score = score;
+            RawScore = rawScore;
         }
 
         public bool Success { get; set; }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -54,9 +54,6 @@ namespace Wox.Infrastructure
         /// 6. Move onto the next substring's characters until all substrings are checked.
         /// 7. Consider success and move onto scoring if every char or substring without whitespaces matched
         /// </summary>
-        /// <params>
-        /// translateLanguage is used to standardise language characters so character matching can be executed.
-        /// </params>
         public MatchResult FuzzyMatch(string query, string stringToCompare, MatchOption opt)
         {
             if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrEmpty(query)) return new MatchResult (false, UserSettingSearchPrecision);

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -258,8 +258,6 @@ namespace Wox.Infrastructure
         /// </summary>
         private int _rawScore;
 
-        private SearchPrecisionScore _searchPrecision;
-
         public int RawScore
         {
             get { return _rawScore; }
@@ -275,15 +273,7 @@ namespace Wox.Infrastructure
         /// </summary>
         public List<int> MatchData { get; set; }
 
-        public SearchPrecisionScore SearchPrecision
-        {
-            get => _searchPrecision;
-            set
-            {
-                _searchPrecision = value;
-                Score = ApplySearchPrecisionFilter(_rawScore);
-            }
-        }
+        public SearchPrecisionScore SearchPrecision { get; set; }
 
         public bool IsSearchPrecisionScoreMet()
         {

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -264,7 +264,7 @@ namespace Wox.Infrastructure
             set
             {
                 _rawScore = value;
-                Score = ApplySearchPrecisionFilter(_rawScore);
+                Score = ScoreAfterSearchPrecisionFilter(_rawScore);
             }
         }
 
@@ -285,7 +285,7 @@ namespace Wox.Infrastructure
             return score >= (int)SearchPrecision;
         }
 
-        private int ApplySearchPrecisionFilter(int score)
+        private int ScoreAfterSearchPrecisionFilter(int rawScore)
         {
             return IsSearchPrecisionScoreMet(score) ? score : 0;
         }

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -59,7 +59,7 @@ namespace Wox.Infrastructure
         /// </params>
         public MatchResult FuzzyMatch(string query, string stringToCompare, MatchOption opt)
         {
-            if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrEmpty(query)) return new MatchResult { Success = false };
+            if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrEmpty(query)) return new MatchResult (false, UserSettingSearchPrecision);
             
             query = query.Trim();
 
@@ -152,18 +152,10 @@ namespace Wox.Infrastructure
             {
                 var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
 
-                var result = new MatchResult
-                {
-                    Success = true,
-                    MatchData = indexList,
-                    RawScore = score,
-                    SearchPrecision = UserSettingSearchPrecision
-                };
-
-                return result;
+                return new MatchResult(true, UserSettingSearchPrecision, indexList, score);
             }
 
-            return new MatchResult { Success = false };
+            return new MatchResult (false, UserSettingSearchPrecision);
         }
 
         private static bool AllPreviousCharsMatched(int startIndexToVerify, int currentQuerySubstringCharacterIndex, 
@@ -240,6 +232,20 @@ namespace Wox.Infrastructure
 
     public class MatchResult
     {
+        public MatchResult(bool success, SearchPrecisionScore searchPrecision)
+        {
+            Success = success;
+            SearchPrecision = searchPrecision;
+        }
+
+        public MatchResult(bool success, SearchPrecisionScore searchPrecision, List<int> matchData, int score)
+        {
+            Success = success;
+            SearchPrecision = searchPrecision;
+            MatchData = matchData;
+            Score = score;
+        }
+
         public bool Success { get; set; }
 
         /// <summary>

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -249,7 +249,7 @@ namespace Wox.Infrastructure
         public bool Success { get; set; }
 
         /// <summary>
-        /// The final score of the match result with all search precision filters applied.
+        /// The final score of the match result with search precision filters applied.
         /// </summary>
         public int Score { get; private set; }
 
@@ -277,17 +277,17 @@ namespace Wox.Infrastructure
 
         public bool IsSearchPrecisionScoreMet()
         {
-            return IsSearchPrecisionScoreMet(Score);
+            return IsSearchPrecisionScoreMet(_rawScore);
         }
 
-        private bool IsSearchPrecisionScoreMet(int score)
+        private bool IsSearchPrecisionScoreMet(int rawScore)
         {
-            return score >= (int)SearchPrecision;
+            return rawScore >= (int)SearchPrecision;
         }
 
         private int ScoreAfterSearchPrecisionFilter(int rawScore)
         {
-            return IsSearchPrecisionScoreMet(score) ? score : 0;
+            return IsSearchPrecisionScoreMet(rawScore) ? rawScore : 0;
         }
     }
 

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -49,18 +49,18 @@ namespace Wox.Infrastructure
         /// 7. Consider success and move onto scoring if every char or substring without whitespaces matched
         /// </summary>
         /// <params>
-        /// convertLanguageToSameChars is used to standardise language characters so character matching can be executed.
+        /// translateLanguage is used to standardise language characters so character matching can be executed.
         /// </params>
-        public static MatchResult FuzzySearch(string query, string stringToCompare, MatchOption opt, Func<string,string> convertLanguageToSameChars = null)
+        public static MatchResult FuzzySearch(string query, string stringToCompare, MatchOption opt, Func<string,string> translateLanguage = null)
         {
             if (string.IsNullOrEmpty(stringToCompare) || string.IsNullOrEmpty(query)) return new MatchResult { Success = false };
             
             query = query.Trim();
 
-            if (convertLanguageToSameChars != null)
+            if (translateLanguage != null)
             {
-                query = convertLanguageToSameChars(query);
-                stringToCompare = convertLanguageToSameChars(stringToCompare);
+                query = translateLanguage(query);
+                stringToCompare = translateLanguage(stringToCompare);
             }
 
             var fullStringToCompareWithoutCase = opt.IgnoreCase ? stringToCompare.ToLower() : stringToCompare;

--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -254,7 +254,7 @@ namespace Wox.Infrastructure
 
         private SearchPrecisionScore _searchPrecision;
 
-        public int RawScore // TODO: remove RawScore if it is only here for testing, then just put SearchPrecisionScore.None to verify Raw score and than use percision in a few tests to verify it is working, it make no sense to be user visible
+        public int RawScore
         {
             get { return _rawScore; }
             set

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -21,19 +21,11 @@ namespace Wox.Infrastructure.UserSettings
         public string ResultFontWeight { get; set; }
         public string ResultFontStretch { get; set; }
 
+
         /// <summary>
         /// when false Alphabet static service will always return empty results
         /// </summary>
-        private bool _shouldUsePinyin = true;
-        public bool ShouldUsePinyin 
-        {
-            get { return _shouldUsePinyin;  }
-            set 
-            {
-                _shouldUsePinyin = value;
-                StringMatcher.ShouldUsePinyin = value;
-            }
-        }
+        public bool ShouldUsePinyin { get; set; } = true;
 
 
         internal StringMatcher.SearchPrecisionScore QuerySearchPrecision { get; private set; } = StringMatcher.SearchPrecisionScore.Regular;
@@ -49,14 +41,14 @@ namespace Wox.Infrastructure.UserSettings
                                             .Parse(typeof(StringMatcher.SearchPrecisionScore), value);
 
                     QuerySearchPrecision = precisionScore;
-                    StringMatcher.UserSettingSearchPrecision = precisionScore;
+                    StringMatcher.Instance.UserSettingSearchPrecision = precisionScore;
                 }
                 catch (ArgumentException e)
                 {
                     Logger.Log.Exception(nameof(Settings), "Failed to load QuerySearchPrecisionString value from Settings file", e);
 
                     QuerySearchPrecision = StringMatcher.SearchPrecisionScore.Regular;
-                    StringMatcher.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.Regular;
+                    StringMatcher.Instance.UserSettingSearchPrecision = StringMatcher.SearchPrecisionScore.Regular;
 
                     throw;
                 }

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -57,12 +57,13 @@ namespace Wox.Test
             };
 
             var results = new List<Result>();
+            var matcher = new StringMatcher();
             foreach (var str in sources)
             {
                 results.Add(new Result
                 {
                     Title = str,
-                    Score = StringMatcher.FuzzySearch("inst", str).RawScore
+                    Score = matcher.FuzzyMatch("inst", str).RawScore
                 });
             }
 
@@ -78,8 +79,8 @@ namespace Wox.Test
         public void WhenGivenNotAllCharactersFoundInSearchStringThenShouldReturnZeroScore(string searchString)
         {
             var compareString = "Can have rum only in my glass";
-
-            var scoreResult = StringMatcher.FuzzySearch(searchString, compareString).RawScore;
+            var matcher = new StringMatcher();
+            var scoreResult = matcher.FuzzyMatch(searchString, compareString).RawScore;
 
             Assert.True(scoreResult == 0);
         }
@@ -93,13 +94,13 @@ namespace Wox.Test
         public void WhenGivenStringsAndAppliedPrecisionFilteringThenShouldReturnGreaterThanPrecisionScoreResults(string searchTerm)
         {
             var results = new List<Result>();
-
+            var matcher = new StringMatcher();
             foreach (var str in GetSearchStrings())
             {
                 results.Add(new Result
                 {
                     Title = str,
-                    Score = StringMatcher.FuzzySearch(searchTerm, str).Score
+                    Score = matcher.FuzzyMatch(searchTerm, str).Score
                 });
             }
 
@@ -131,7 +132,8 @@ namespace Wox.Test
         public void WhenGivenQueryStringThenShouldReturnCurrentScoring(string queryString, string compareString, int expectedScore)
         {
             // When, Given
-            var rawScore = StringMatcher.FuzzySearch(queryString, compareString).RawScore;
+            var matcher = new StringMatcher();
+            var rawScore = matcher.FuzzyMatch(queryString, compareString).RawScore;
 
             // Should
             Assert.AreEqual(expectedScore, rawScore, $"Expected score for compare string '{compareString}': {expectedScore}, Actual: {rawScore}");
@@ -154,10 +156,10 @@ namespace Wox.Test
             bool expectedPrecisionResult)
         {
             // When            
-            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore;
+            var matcher = new StringMatcher {UserSettingSearchPrecision = expectedPrecisionScore};
 
             // Given
-            var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
+            var matchResult = matcher.FuzzyMatch(queryString, compareString);
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");
@@ -200,10 +202,10 @@ namespace Wox.Test
             bool expectedPrecisionResult)
         {
             // When
-            StringMatcher.UserSettingSearchPrecision = expectedPrecisionScore;
+            var matcher = new StringMatcher { UserSettingSearchPrecision = expectedPrecisionScore };
 
             // Given
-            var matchResult = StringMatcher.FuzzySearch(queryString, compareString);
+            var matchResult = matcher.FuzzyMatch(queryString, compareString);
 
             Debug.WriteLine("");
             Debug.WriteLine("###############################################");

--- a/Wox/App.xaml.cs
+++ b/Wox/App.xaml.cs
@@ -26,6 +26,8 @@ namespace Wox
         private MainViewModel _mainVM;
         private SettingWindowViewModel _settingsVM;
         private readonly Updater _updater = new Updater(Wox.Properties.Settings.Default.GithubRepo);
+        private readonly Alphabet _alphabet = new Alphabet();
+        private StringMatcher _stringMatcher;
 
         [STAThread]
         public static void Main()
@@ -54,15 +56,14 @@ namespace Wox
                 _settingsVM = new SettingWindowViewModel(_updater);
                 _settings = _settingsVM.Settings;
 
-                Alphabet.Initialize(_settings);
-
-                StringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
-                StringMatcher.ShouldUsePinyin = _settings.ShouldUsePinyin;
+                _alphabet.Initialize(_settings);
+                StringMatcher.Instance = new StringMatcher(_alphabet);
+                _stringMatcher.UserSettingSearchPrecision = _settings.QuerySearchPrecision;
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);
                 _mainVM = new MainViewModel(_settings);
                 var window = new MainWindow(_settings, _mainVM);
-                API = new PublicAPIInstance(_settingsVM, _mainVM);
+                API = new PublicAPIInstance(_settingsVM, _mainVM, _alphabet);
                 PluginManager.InitializePlugins(API);
                 Log.Info($"|App.OnStartup|Dependencies Info:{ErrorReporting.DependenciesInfo()}");
 
@@ -158,13 +159,7 @@ namespace Wox
             // but if sessionending is not called, exit won't be called when log off / shutdown
             if (!_disposed)
             {
-                _mainVM.Save();
-                _settingsVM.Save();
-
-                PluginManager.Save();
-                ImageLoader.Save();
-                Alphabet.Save();
-
+                API.SaveAppAllSettings();
                 _disposed = true;
             }
         }

--- a/Wox/PublicAPIInstance.cs
+++ b/Wox/PublicAPIInstance.cs
@@ -20,16 +20,17 @@ namespace Wox
     {
         private readonly SettingWindowViewModel _settingsVM;
         private readonly MainViewModel _mainVM;
+        private readonly Alphabet _alphabet;
 
         #region Constructor
 
-        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM)
+        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM, Alphabet alphabet)
         {
             _settingsVM = settingsVM;
             _mainVM = mainVM;
+            _alphabet = alphabet;
             GlobalHotkey.Instance.hookedKeyboardCallback += KListener_hookedKeyboardCallback;
             WebRequest.RegisterPrefix("data", new DataWebRequestFactory());
-
         }
 
         #endregion
@@ -70,7 +71,7 @@ namespace Wox
             _settingsVM.Save();
             PluginManager.Save();
             ImageLoader.Save();
-            Alphabet.Save();
+            _alphabet.Save();
         }
 
         public void ReloadAllPluginData()


### PR DESCRIPTION
Problem context:
1. Pinyin search not working as intended. #111
1. ScoreForPinyin code is inefficiently looping FuzzySearch method

Resolution:
- Separated out ScoreForPinyin code
- Added Inversion of Control by creating abstraction of the code that converts Chinese characters to Pinyin

Result:
![image](https://user-images.githubusercontent.com/26427004/72514908-23d1d400-38a3-11ea-823b-29d8dadf82d3.png)

![image](https://user-images.githubusercontent.com/26427004/72515024-5d0a4400-38a3-11ea-8fb5-97bac873ab8f.png)

