### PR TITLE
Enabling ClearType on Wox

### DIFF
--- a/Wox/MainWindow.xaml
+++ b/Wox/MainWindow.xaml
@@ -63,7 +63,7 @@
             <Grid>
                 <TextBox x:Name="QueryTextSuggestionBox"
                          Style="{DynamicResource QueryBoxStyle}"
-                         Foreground="LightGray"
+                         Foreground="DarkGray"
                          IsEnabled="False">
                     <TextBox.Text>
                         <MultiBinding Converter="{StaticResource QuerySuggestionBoxConverter}">

--- a/Wox/Themes/Base.xaml
+++ b/Wox/Themes/Base.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <Style x:Key="BaseQueryBoxStyle" TargetType="{x:Type TextBox}">
@@ -11,6 +11,24 @@
         <Setter Property="CaretBrush" Value="#E3E0E3" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
+                                      Background="{TemplateBinding Background}">
+                            <ScrollViewer.ContentTemplate>
+                                <DataTemplate>
+                                    <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled">
+                                        <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"></ContentPresenter>
+                                    </Grid>
+                                </DataTemplate>
+                            </ScrollViewer.ContentTemplate>
+                        </ScrollViewer>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
     <Style x:Key="BaseWindowBorderStyle" TargetType="{x:Type Border}">
         <Setter Property="BorderThickness" Value="0" />
@@ -32,23 +50,28 @@
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseItemSubTitleStyle" TargetType="{x:Type TextBlock}" >
         <Setter Property="Foreground" Value="#D9D9D4" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseItemNumberStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="Margin" Value="3 0 0 0" />
         <Setter Property="FontSize" Value="22" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseItemTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseItemSubTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
         <Setter Property="Foreground" Value="#D9D9D4" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
 
     <Style x:Key="BaseListboxStyle" TargetType="{x:Type ListBox}">


### PR DESCRIPTION
Context:
Enables ClearType font smoothing for text in Wox.

[Note](https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.renderoptions.cleartypehint?view=netframework-4.5.2): ClearType text does not display correctly on a background that is not fully opaque. Intermediate render targets, such as Effect, OpacityMask, VisualBrush, DrawingBrush, Clip, and Opacity, can introduce backgrounds that are not fully opaque. WPF disables ClearType when it detects that the buffer into which text is drawn could have a transparent background.

Feature requested: https://github.com/jjw24/Wox/issues/108