### PR TITLE
Fix issue incorrect dll reference

### DIFF
--- a/Wox.Core/Wox.Core.csproj
+++ b/Wox.Core/Wox.Core.csproj
@@ -103,9 +103,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SharpZipLib">
-      <Version>1.2.0</Version>
-    </PackageReference>
     <PackageReference Include="squirrel.windows">
       <Version>1.5.2</Version>
     </PackageReference>

--- a/Wox/Wox.csproj
+++ b/Wox/Wox.csproj
@@ -431,9 +431,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SharpZipLib">
-      <Version>0.86.0</Version>
-    </PackageReference>
     <PackageReference Include="squirrel.windows">
       <Version>1.5.2</Version>
     </PackageReference>


### PR DESCRIPTION
Prior to the PackageReferences upgrade:
![image](https://user-images.githubusercontent.com/26427004/74464467-a9b75e00-4ee7-11ea-99eb-c543670e0fb8.png)


SharpZipLib dll already exists in squirrel.windows and should be using that, so removing duplicate reference which is pointing to the wrong version of SharpZipLib as well.

Resolves issues where unable to install any external plugins as well as https://github.com/jjw24/Wox/issues/136