### PR TITLE
Reduce Wox's drain on CPU when using Pinyin search

### DIFF
--- a/Wox.Core/Resource/Internationalization.cs
+++ b/Wox.Core/Resource/Internationalization.cs
@@ -99,6 +99,22 @@ namespace Wox.Core.Resource
 
         }
 
+        public bool PromptShouldUsePinyin(string languageCodeToSet)
+        {
+            var languageToSet = GetLanguageByLanguageCode(languageCodeToSet);
+
+            if (Settings.ShouldUsePinyin)
+                return false;
+
+            if (languageToSet != AvailableLanguages.Chinese && languageToSet != AvailableLanguages.Chinese_TW)
+                return false;
+
+            if (MessageBox.Show("Do you want to turn on search with Pinyin?", string.Empty, MessageBoxButton.YesNo) == MessageBoxResult.No)
+                return false;
+
+            return true;
+        }
+
         private void RemoveOldLanguageFiles()
         {
             var dicts = Application.Current.Resources.MergedDictionaries;

--- a/Wox.Infrastructure/Alphabet.cs
+++ b/Wox.Infrastructure/Alphabet.cs
@@ -162,7 +162,7 @@ namespace Wox.Infrastructure
 
             if (word.Length > 40)
             {
-                Log.Debug($"|Wox.Infrastructure.StringMatcher.ScoreForPinyin|skip too long string: {word}");
+                //Skip strings that are too long string for Pinyin conversion.
                 return false;
             }
 

--- a/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/Wox.Infrastructure/UserSettings/Settings.cs
@@ -25,8 +25,7 @@ namespace Wox.Infrastructure.UserSettings
         /// <summary>
         /// when false Alphabet static service will always return empty results
         /// </summary>
-        public bool ShouldUsePinyin { get; set; } = true;
-
+        public bool ShouldUsePinyin { get; set; } = false;
 
         internal StringMatcher.SearchPrecisionScore QuerySearchPrecision { get; private set; } = StringMatcher.SearchPrecisionScore.Regular;
 

--- a/Wox/SettingWindow.xaml
+++ b/Wox/SettingWindow.xaml
@@ -55,7 +55,7 @@
                 <CheckBox Margin="10" IsChecked="{Binding Settings.AutoUpdates}">
                     <TextBlock Text="{DynamicResource autoUpdates}" />
                 </CheckBox>
-                <CheckBox Margin="10" IsChecked="{Binding Settings.ShouldUsePinyin}">
+                <CheckBox Margin="10" IsChecked="{Binding ShouldUsePinyin}">
                     <TextBlock Text="{DynamicResource ShouldUsePinyin}" />
                 </CheckBox>
                 <StackPanel Margin="10" Orientation="Horizontal">
@@ -72,8 +72,8 @@
                 </StackPanel>
                 <StackPanel Margin="10" Orientation="Horizontal">
                     <TextBlock Text="{DynamicResource language}" />
-                    <ComboBox Margin="10 0 0 0" Width="120" SelectionChanged="OnLanguageChanged"
-                              ItemsSource="{Binding Languages}" SelectedValue="{Binding Settings.Language}"
+                    <ComboBox Margin="10 0 0 0" Width="120"
+                              ItemsSource="{Binding Languages}" SelectedValue="{Binding Language}"
                               DisplayMemberPath="Display" SelectedValuePath="LanguageCode" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="10">

--- a/Wox/SettingWindow.xaml.cs
+++ b/Wox/SettingWindow.xaml.cs
@@ -40,12 +40,6 @@ namespace Wox
 
         #region General
 
-        void OnLanguageChanged(object sender, SelectionChangedEventArgs e)
-        {
-            var language = (Language)e.AddedItems[0];
-            InternationalizationManager.Instance.ChangeLanguage(language);
-        }
-
         private void OnAutoStartupChecked(object sender, RoutedEventArgs e)
         {
             SetStartup();

--- a/Wox/ViewModel/SettingWindowViewModel.cs
+++ b/Wox/ViewModel/SettingWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -74,6 +74,33 @@ namespace Wox.ViewModel
                     modes.Add(m);
                 }
                 return modes;
+            }
+        }
+
+        public string Language
+        {
+            get
+            {
+                return Settings.Language;
+            }
+            set
+            {
+                InternationalizationManager.Instance.ChangeLanguage(value);
+
+                if (InternationalizationManager.Instance.PromptShouldUsePinyin(value))
+                    ShouldUsePinyin = true;
+            }
+        }
+
+        public bool ShouldUsePinyin
+        {
+            get 
+            {
+                return Settings.ShouldUsePinyin;            
+            }
+            set 
+            {
+                Settings.ShouldUsePinyin = value;
             }
         }
 


### PR DESCRIPTION
This logging is very excessive when using Pinyin search as a lot of strings coming from Program plugin's application description and Control Panel's item description are very long, causing logging on everyone of them and draining on performance.

![image](https://user-images.githubusercontent.com/26427004/76353293-92438780-6364-11ea-852a-b02779578450.png)

Current drain
ContainsChinese(string)- 9551 units (38.69%)
![image](https://user-images.githubusercontent.com/26427004/76353444-dcc50400-6364-11ea-9243-05757bc83ace.png)

After removing logging- 17 units (0.10%)
ContainsChinese(string)
![image](https://user-images.githubusercontent.com/26427004/76353638-2dd4f800-6365-11ea-8ff3-83211dd08a82.png)

After removing logging
FuzzyMatch()
![image](https://user-images.githubusercontent.com/26427004/76353898-a2a83200-6365-11ea-807f-c598b91b9e0d.png)

Additional change to ShouldUsePinyin option selection:
1. Change  default start up not to use Pinyin as default language is English (When no user data exists)
2. Add prompt when switching to Chinese or Chinese_TW prompt user if they want to use Pinyin search.