### PR TITLE
Provide user the option to switch on/off highlighting of how results are matched

### DIFF
--- a/Plugins/Wox.Plugin.ControlPanel/ControlPanelSettings.xaml
+++ b/Plugins/Wox.Plugin.ControlPanel/ControlPanelSettings.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="Wox.Plugin.ControlPanel.ControlPanelSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Width="130" HorizontalAlignment="Left">
+            <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click" Margin="5" Content="Highlight Results" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Plugins/Wox.Plugin.ControlPanel/ControlPanelSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.ControlPanel/ControlPanelSettings.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace Wox.Plugin.ControlPanel
+{
+    /// <summary>
+    /// Interaction logic for ControlPanelSettings.xaml
+    /// </summary>
+    public partial class ControlPanelSettings : UserControl
+    {
+        public ControlPanelSettings()
+        {
+            InitializeComponent();
+
+            HighlightResultsEnabled.IsChecked = Main._settings.EnableHighlightData;
+        }
+
+        private void HighlightResults_Click(object sender, RoutedEventArgs e)
+        {
+            Main._settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.ControlPanel/Main.cs
+++ b/Plugins/Wox.Plugin.ControlPanel/Main.cs
@@ -3,17 +3,26 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Windows.Controls;
 using Wox.Infrastructure;
+using Wox.Infrastructure.Storage;
 
 namespace Wox.Plugin.ControlPanel
 {
-    public class Main : IPlugin, IPluginI18n
+    public class Main : IPlugin, IPluginI18n, ISavable, ISettingProvider
     {
         private PluginInitContext context;
         private List<ControlPanelItem> controlPanelItems = new List<ControlPanelItem>();
         private string iconFolder;
         private string fileType;
+        internal static Settings _settings { get; set; }
+        private readonly PluginJsonStorage<Settings> _settingsStorage;
+
+        public Main()
+        {
+            _settingsStorage = new PluginJsonStorage<Settings>();
+            _settings = _settingsStorage.Load();
+        }
 
         public void Init(PluginInitContext context)
         {
@@ -71,11 +80,15 @@ namespace Wox.Plugin.ControlPanel
 
                     if (item.Score == titleMatch.Score)
                     {
-                        result.TitleHighlightData = titleMatch.MatchData;
+                        result.TitleHighlightData = _settings.EnableHighlightData
+                                                        ? titleMatch.MatchData
+                                                        : null;
                     }
                     else
                     {
-                        result.SubTitleHighlightData = subTitleMatch.MatchData;
+                        result.SubTitleHighlightData = _settings.EnableHighlightData
+                                                       ? subTitleMatch.MatchData
+                                                       : null ;
                     }
 
                     results.Add(result);
@@ -94,6 +107,16 @@ namespace Wox.Plugin.ControlPanel
         public string GetTranslatedPluginDescription()
         {
             return context.API.GetTranslation("wox_plugin_controlpanel_plugin_description");
+        }
+
+        public void Save()
+        {
+            _settingsStorage.Save();
+        }
+
+        public Control CreateSettingPanel()
+        {
+            return new ControlPanelSettings();
         }
     }
 }

--- a/Plugins/Wox.Plugin.ControlPanel/Settings.cs
+++ b/Plugins/Wox.Plugin.ControlPanel/Settings.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Wox.Plugin.ControlPanel
+{
+    internal class Settings
+    {
+        public bool EnableHighlightData { get; set; } = false;
+    }
+}

--- a/Plugins/Wox.Plugin.ControlPanel/Wox.Plugin.ControlPanel.csproj
+++ b/Plugins/Wox.Plugin.ControlPanel/Wox.Plugin.ControlPanel.csproj
@@ -37,10 +37,13 @@
       <HintPath>..\..\packages\JetBrains.Annotations.10.3.0\lib\net\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SolutionAssemblyInfo.cs">
@@ -50,6 +53,10 @@
     <Compile Include="ControlPanelItem.cs" />
     <Compile Include="ControlPanelList.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Settings.cs" />
+    <Compile Include="ControlPanelSettings.xaml.cs">
+      <DependentUpon>ControlPanelSettings.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="plugin.json">
@@ -120,6 +127,12 @@
     <PackageReference Include="System.Runtime">
       <Version>4.0.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="ControlPanelSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml
+++ b/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml
@@ -11,16 +11,20 @@
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
+                <RowDefinition/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition Width="*"></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <CheckBox Grid.Row="0" Grid.ColumnSpan="3" x:Name="UseLocationAsWorkingDir" Content="{DynamicResource wox_plugin_everything_use_location_as_working_dir}" Margin="10" HorizontalAlignment="Left" />
-            <Label Grid.Row="1" Margin="10" Content="{DynamicResource wox_plugin_everything_editor_path}"  HorizontalAlignment="Left"/>
-            <Label Grid.Row="1" Grid.Column="1" x:Name="EditorPath" Margin="10" HorizontalAlignment="Stretch" />
-            <Button Grid.Row="1" Grid.Column="2" x:Name="OpenEditorPath" Content="..." Margin="10" HorizontalAlignment="Right" Click="EditorPath_Clicked"/>
+            <StackPanel Grid.Row="0" Width="130" HorizontalAlignment="Left">
+                <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click" Margin="10,0,0,0" Content="Highlight Results" />
+            </StackPanel>
+            <CheckBox Grid.Row="1" Grid.ColumnSpan="3" x:Name="UseLocationAsWorkingDir" Content="{DynamicResource wox_plugin_everything_use_location_as_working_dir}" Margin="10" HorizontalAlignment="Left" />
+            <Label Grid.Row="2" Margin="10" Content="{DynamicResource wox_plugin_everything_editor_path}"  HorizontalAlignment="Left"/>
+            <Label Grid.Row="2" Grid.Column="1" x:Name="EditorPath" Margin="10" HorizontalAlignment="Stretch" />
+            <Button Grid.Row="2" Grid.Column="2" x:Name="OpenEditorPath" Content="..." Margin="10" HorizontalAlignment="Right" Click="EditorPath_Clicked"/>
         </Grid>
     </Border>
 </UserControl>

--- a/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.Everything/EverythingSettings.xaml.cs
@@ -29,6 +29,8 @@ namespace Wox.Plugin.Everything
             };
 
             EditorPath.Content = _settings.EditorPath;
+
+            HighlightResultsEnabled.IsChecked = _settings.EnableHighlightData;
         }
 
         private void EditorPath_Clicked(object sender, RoutedEventArgs e)
@@ -44,6 +46,11 @@ namespace Wox.Plugin.Everything
             }
 
             EditorPath.Content = _settings.EditorPath;
+        }
+
+        private void HighlightResults_Click(object sender, RoutedEventArgs e)
+        {
+            _settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.Everything/Main.cs
+++ b/Plugins/Wox.Plugin.Everything/Main.cs
@@ -97,7 +97,9 @@ namespace Wox.Plugin.Everything
                 Title = Path.GetFileName(path),
                 SubTitle = path,
                 IcoPath = path,
-                TitleHighlightData = StringMatcher.FuzzySearch(keyword, Path.GetFileName(path)).MatchData,
+                TitleHighlightData = _settings.EnableHighlightData
+                                        ? StringMatcher.FuzzySearch(keyword, Path.GetFileName(path)).MatchData
+                                        : null,
                 Action = c =>
                 {
                     bool hide;
@@ -120,7 +122,9 @@ namespace Wox.Plugin.Everything
                     return hide;
                 },
                 ContextData = searchResult,
-                SubTitleHighlightData = StringMatcher.FuzzySearch(keyword, path).MatchData
+                SubTitleHighlightData = _settings.EnableHighlightData
+                                            ? StringMatcher.FuzzySearch(keyword, path).MatchData
+                                            : null
             };
             return r;
         }

--- a/Plugins/Wox.Plugin.Everything/Settings.cs
+++ b/Plugins/Wox.Plugin.Everything/Settings.cs
@@ -16,6 +16,8 @@ namespace Wox.Plugin.Everything
         public int MaxSearchCount { get; set; } = DefaultMaxSearchCount;
 
         public bool UseLocationAsWorkingDir { get; set; } = false;
+        
+        public bool EnableHighlightData { get; set; } = false;
     }
 
     public class ContextMenu

--- a/Plugins/Wox.Plugin.Folder/FolderPluginSettings.xaml
+++ b/Plugins/Wox.Plugin.Folder/FolderPluginSettings.xaml
@@ -7,10 +7,14 @@
 			 d:DesignHeight="300" d:DesignWidth="500">
 	<Grid Margin="10">
 		<Grid.RowDefinitions>
-			<RowDefinition Height="*"/>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="*"/>
 			<RowDefinition Height="50"/>
 		</Grid.RowDefinitions>
-        <ListView x:Name="lbxFolders" Grid.Row="0" AllowDrop="True"
+        <StackPanel Grid.Row="0" Width="130" HorizontalAlignment="Left">
+            <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click" Margin="5" Content="Highlight Results" />
+        </StackPanel>
+        <ListView x:Name="lbxFolders" Grid.Row="1" AllowDrop="True"
                  Drop="lbxFolders_Drop"
                  DragEnter="lbxFolders_DragEnter">
             <ListView.View>
@@ -25,7 +29,7 @@
 				</GridView>
 			</ListView.View>
 		</ListView>
-		<StackPanel Grid.Row="1" HorizontalAlignment="Right" Orientation="Horizontal">
+		<StackPanel Grid.Row="2" HorizontalAlignment="Right" Orientation="Horizontal">
 			<Button x:Name="btnDelete" Click="btnDelete_Click" Width="100" Margin="10" Content="{DynamicResource wox_plugin_folder_delete}"/>
             <Button x:Name="btnEdit" Click="btnEdit_Click" Width="100" Margin="10" Content="{DynamicResource wox_plugin_folder_edit}"/>
             <Button x:Name="btnAdd" Click="btnAdd_Click" Width="100" Margin="10" Content="{DynamicResource wox_plugin_folder_add}"/>

--- a/Plugins/Wox.Plugin.Folder/FolderPluginSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.Folder/FolderPluginSettings.xaml.cs
@@ -22,6 +22,7 @@ namespace Wox.Plugin.Folder
             InitializeComponent();
             _settings = settings;
             lbxFolders.ItemsSource = _settings.FolderLinks;
+            HighlightResultsEnabled.IsChecked = _settings.EnableHighlightData;
         }
 
         private void btnDelete_Click(object sender, RoutedEventArgs e)
@@ -125,6 +126,11 @@ namespace Wox.Plugin.Folder
             {
                 e.Effects = DragDropEffects.None;
             }
+        }
+
+        private void HighlightResults_Click(object sender, RoutedEventArgs e)
+        {
+            _settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/Plugins/Wox.Plugin.Folder/Main.cs
@@ -95,7 +95,9 @@ namespace Wox.Plugin.Folder
                 Title = title,
                 IcoPath = path,
                 SubTitle = subtitle,
-                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
+                TitleHighlightData = _settings.EnableHighlightData
+                                        ? StringMatcher.FuzzySearch(query.Search, title).MatchData
+                                        : null,
                 Action = c =>
                 {
                     if (c.SpecialKeyState.CtrlPressed)
@@ -222,7 +224,7 @@ namespace Wox.Plugin.Folder
                     }
                     else
                     {
-                        fileList.Add(CreateFileResult(fileSystemInfo.FullName, query));
+                        fileList.Add(CreateFileResult(fileSystemInfo.FullName, query, _settings.EnableHighlightData));
                     }
                 }
             }
@@ -242,14 +244,16 @@ namespace Wox.Plugin.Folder
             return results.Concat(folderList.OrderBy(x => x.Title)).Concat(fileList.OrderBy(x => x.Title)).ToList();
         }
 
-        private static Result CreateFileResult(string filePath, Query query)
+        private static Result CreateFileResult(string filePath, Query query, bool enableHighlightData)
         {
             var result = new Result
             {
                 Title = Path.GetFileName(filePath),
                 SubTitle = filePath,
                 IcoPath = filePath,
-                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
+                TitleHighlightData = enableHighlightData
+                                        ? StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData
+                                        : null,
                 Action = c =>
                 {
                     try

--- a/Plugins/Wox.Plugin.Folder/Settings.cs
+++ b/Plugins/Wox.Plugin.Folder/Settings.cs
@@ -8,5 +8,7 @@ namespace Wox.Plugin.Folder
     {
         [JsonProperty]
         public List<FolderLink> FolderLinks { get; set; } = new List<FolderLink>();
+        
+        public bool EnableHighlightData { get; set; } = false;
     }
 }

--- a/Plugins/Wox.Plugin.PluginManagement/PluginManagementSettings.xaml
+++ b/Plugins/Wox.Plugin.PluginManagement/PluginManagementSettings.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Wox.Plugin.PluginManagement.PluginManagementSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Wox.Plugin.PluginManagement"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Width="130" HorizontalAlignment="Left">
+            <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click" Margin="5" Content="Highlight Results" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Plugins/Wox.Plugin.PluginManagement/PluginManagementSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.PluginManagement/PluginManagementSettings.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Wox.Plugin.PluginManagement
+{
+    /// <summary>
+    /// Interaction logic for PluginManagementSettings.xaml
+    /// </summary>
+    public partial class PluginManagementSettings : UserControl
+    {
+        public PluginManagementSettings()
+        {
+            InitializeComponent();
+
+            HighlightResultsEnabled.IsChecked = Main._settings.EnableHighlightData;
+        }
+
+        private void HighlightResults_Click(object sender, RoutedEventArgs e)
+        {
+            Main._settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
+        }
+    }
+}

--- a/Plugins/Wox.Plugin.PluginManagement/Settings.cs
+++ b/Plugins/Wox.Plugin.PluginManagement/Settings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Wox.Plugin.PluginManagement
+{
+    internal class Settings
+    {
+        public bool EnableHighlightData { get; set; } = false;
+    }
+}

--- a/Plugins/Wox.Plugin.PluginManagement/Wox.Plugin.PluginManagement.csproj
+++ b/Plugins/Wox.Plugin.PluginManagement/Wox.Plugin.PluginManagement.csproj
@@ -34,11 +34,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Presentation" />
+    <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -46,7 +48,11 @@
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Main.cs" />
+    <Compile Include="PluginManagementSettings.xaml.cs">
+      <DependentUpon>PluginManagementSettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="WoxPluginResult.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -121,6 +127,12 @@
     <PackageReference Include="System.Runtime">
       <Version>4.0.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="PluginManagementSettings.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -298,7 +298,7 @@ namespace Wox.Plugin.Program.Programs
                     result.Title = Description;
                     result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, Description).MatchData 
-                                                    : new List<int>();
+                                                    : null;
                 }
                 else if (!string.IsNullOrEmpty(Description))
                 {
@@ -306,14 +306,14 @@ namespace Wox.Plugin.Program.Programs
                     result.Title = title;
                     result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, title).MatchData 
-                                                    : new List<int>();
+                                                    : null;
                 }
                 else
                 {
                     result.Title = DisplayName;
                     result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, DisplayName).MatchData 
-                                                    : new List<int>();
+                                                    : null;
                 }
                 return result;
             }

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -296,7 +296,7 @@ namespace Wox.Plugin.Program.Programs
                     Description.Substring(0, DisplayName.Length) == DisplayName)
                 {
                     result.Title = Description;
-                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                    result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, Description).MatchData 
                                                     : new List<int>();
                 }
@@ -304,14 +304,14 @@ namespace Wox.Plugin.Program.Programs
                 {
                     var title = $"{DisplayName}: {Description}";
                     result.Title = title;
-                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                    result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, title).MatchData 
                                                     : new List<int>();
                 }
                 else
                 {
                     result.Title = DisplayName;
-                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                    result.TitleHighlightData = Main._settings.EnableHighlightData
                                                     ? StringMatcher.FuzzySearch(query, DisplayName).MatchData 
                                                     : new List<int>();
                 }

--- a/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -296,18 +296,24 @@ namespace Wox.Plugin.Program.Programs
                     Description.Substring(0, DisplayName.Length) == DisplayName)
                 {
                     result.Title = Description;
-                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
+                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                    ? StringMatcher.FuzzySearch(query, Description).MatchData 
+                                                    : new List<int>();
                 }
                 else if (!string.IsNullOrEmpty(Description))
                 {
                     var title = $"{DisplayName}: {Description}";
                     result.Title = title;
-                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, title).MatchData;
+                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                    ? StringMatcher.FuzzySearch(query, title).MatchData 
+                                                    : new List<int>();
                 }
                 else
                 {
                     result.Title = DisplayName;
-                    result.TitleHighlightData = StringMatcher.FuzzySearch(query, DisplayName).MatchData;
+                    result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                    ? StringMatcher.FuzzySearch(query, DisplayName).MatchData 
+                                                    : new List<int>();
                 }
                 return result;
             }

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -75,18 +75,24 @@ namespace Wox.Plugin.Program.Programs
                 Description.Substring(0, Name.Length) == Name)
             {
                 result.Title = Description;
-                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Description).MatchData;
+                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                ? StringMatcher.FuzzySearch(query, Description).MatchData 
+                                                : new List<int>();
             }
             else if (!string.IsNullOrEmpty(Description))
             {
                 var title = $"{Name}: {Description}";
                 result.Title = title;
-                result.TitleHighlightData = StringMatcher.FuzzySearch(query, title).MatchData;
+                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                ? StringMatcher.FuzzySearch(query, title).MatchData 
+                                                : new List<int>();
             }
             else
             {
                 result.Title = Name;
-                result.TitleHighlightData = StringMatcher.FuzzySearch(query, Name).MatchData;
+                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                                                ? StringMatcher.FuzzySearch(query, Name).MatchData 
+                                                : new List<int>();
             }
 
             return result;

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -75,7 +75,7 @@ namespace Wox.Plugin.Program.Programs
                 Description.Substring(0, Name.Length) == Name)
             {
                 result.Title = Description;
-                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, Description).MatchData 
                                                 : new List<int>();
             }
@@ -83,14 +83,14 @@ namespace Wox.Plugin.Program.Programs
             {
                 var title = $"{Name}: {Description}";
                 result.Title = title;
-                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, title).MatchData 
                                                 : new List<int>();
             }
             else
             {
                 result.Title = Name;
-                result.TitleHighlightData = Main._settings.ShouldHighlightData 
+                result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, Name).MatchData 
                                                 : new List<int>();
             }

--- a/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -77,7 +77,7 @@ namespace Wox.Plugin.Program.Programs
                 result.Title = Description;
                 result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, Description).MatchData 
-                                                : new List<int>();
+                                                : null;
             }
             else if (!string.IsNullOrEmpty(Description))
             {
@@ -85,14 +85,14 @@ namespace Wox.Plugin.Program.Programs
                 result.Title = title;
                 result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, title).MatchData 
-                                                : new List<int>();
+                                                : null;
             }
             else
             {
                 result.Title = Name;
                 result.TitleHighlightData = Main._settings.EnableHighlightData
                                                 ? StringMatcher.FuzzySearch(query, Name).MatchData 
-                                                : new List<int>();
+                                                : null;
             }
 
             return result;

--- a/Plugins/Wox.Plugin.Program/Settings.cs
+++ b/Plugins/Wox.Plugin.Program/Settings.cs
@@ -15,7 +15,7 @@ namespace Wox.Plugin.Program
 
         public bool EnableRegistrySource { get; set; } = true;
 
-        internal bool ShouldHighlightData { get; set; } = false;
+        internal bool EnableHighlightData { get; set; } = false;
 
         internal const char SuffixSeperator = ';';
 

--- a/Plugins/Wox.Plugin.Program/Settings.cs
+++ b/Plugins/Wox.Plugin.Program/Settings.cs
@@ -15,6 +15,8 @@ namespace Wox.Plugin.Program
 
         public bool EnableRegistrySource { get; set; } = true;
 
+        internal bool ShouldHighlightData { get; set; } = false;
+
         internal const char SuffixSeperator = ';';
 
         /// <summary>

--- a/Plugins/Wox.Plugin.Program/Settings.cs
+++ b/Plugins/Wox.Plugin.Program/Settings.cs
@@ -15,7 +15,7 @@ namespace Wox.Plugin.Program
 
         public bool EnableRegistrySource { get; set; } = true;
 
-        internal bool EnableHighlightData { get; set; } = false;
+        public bool EnableHighlightData { get; set; } = false;
 
         internal const char SuffixSeperator = ';';
 

--- a/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml
@@ -8,7 +8,7 @@
              d:DesignHeight="300" d:DesignWidth="600">
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="50"/>
+            <RowDefinition Height="80"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
@@ -16,6 +16,7 @@
             <StackPanel Orientation="Vertical" Width="205">
                 <CheckBox Name="StartMenuEnabled" Click="StartMenuEnabled_Click" Margin="5" Content="{DynamicResource wox_plugin_program_index_start}" />
                 <CheckBox Name="RegistryEnabled" Click="RegistryEnabled_Click"  Margin="5" Content="{DynamicResource wox_plugin_program_index_registry}" />
+                <CheckBox x:Name="HighlightResultsEnabled" Click="HighlightResults_Click"  Margin="5" Content="Highlight Results" />
             </StackPanel>
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button Height="30" HorizontalAlignment="Right" Margin="10" Width="100" x:Name="btnLoadAllProgramSource" Click="btnLoadAllProgramSource_OnClick" Content="{DynamicResource wox_plugin_program_all_programs}" />

--- a/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml
@@ -16,7 +16,7 @@
             <StackPanel Orientation="Vertical" Width="205">
                 <CheckBox Name="StartMenuEnabled" Click="StartMenuEnabled_Click" Margin="5" Content="{DynamicResource wox_plugin_program_index_start}" />
                 <CheckBox Name="RegistryEnabled" Click="RegistryEnabled_Click"  Margin="5" Content="{DynamicResource wox_plugin_program_index_registry}" />
-                <CheckBox x:Name="HighlightResultsEnabled" Click="HighlightResults_Click"  Margin="5" Content="Highlight Results" />
+                <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click"  Margin="5" Content="Highlight Results" />
             </StackPanel>
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button Height="30" HorizontalAlignment="Right" Margin="10" Width="100" x:Name="btnLoadAllProgramSource" Click="btnLoadAllProgramSource_OnClick" Content="{DynamicResource wox_plugin_program_all_programs}" />

--- a/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -42,7 +42,7 @@ namespace Wox.Plugin.Program.Views
 
             StartMenuEnabled.IsChecked = _settings.EnableStartMenuSource;
             RegistryEnabled.IsChecked = _settings.EnableRegistrySource;
-            HighlightResultsEnabled.IsChecked = _settings.ShouldHighlightData;
+            HighlightResultsEnabled.IsChecked = _settings.EnableHighlightData;
         }
 
         private void ReIndexing()
@@ -307,7 +307,7 @@ namespace Wox.Plugin.Program.Views
 
         private void HighlightResults_Click(object sender, RoutedEventArgs e)
         {
-            _settings.ShouldHighlightData = HighlightResultsEnabled.IsChecked ?? false;
+            _settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Wox.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -42,6 +42,7 @@ namespace Wox.Plugin.Program.Views
 
             StartMenuEnabled.IsChecked = _settings.EnableStartMenuSource;
             RegistryEnabled.IsChecked = _settings.EnableRegistrySource;
+            HighlightResultsEnabled.IsChecked = _settings.ShouldHighlightData;
         }
 
         private void ReIndexing()
@@ -302,6 +303,11 @@ namespace Wox.Plugin.Program.Views
             {
                 btnProgramSourceStatus.Content = "Enable";
             }
+        }
+
+        private void HighlightResults_Click(object sender, RoutedEventArgs e)
+        {
+            _settings.ShouldHighlightData = HighlightResultsEnabled.IsChecked ?? false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Interop;
 using Wox.Infrastructure;
+using Wox.Infrastructure.Storage;
 using Application = System.Windows.Application;
 using Control = System.Windows.Controls.Control;
 using FormsApplication = System.Windows.Forms.Application;
@@ -13,9 +14,11 @@ using MessageBox = System.Windows.MessageBox;
 
 namespace Wox.Plugin.Sys
 {
-    public class Main : IPlugin, ISettingProvider, IPluginI18n
+    public class Main : IPlugin, ISettingProvider, IPluginI18n, ISavable
     {
         private PluginInitContext context;
+        public static Settings _settings { get; set; }
+        private readonly PluginJsonStorage<Settings> _settingsStorage;
 
         #region DllImport
 
@@ -44,6 +47,12 @@ namespace Wox.Plugin.Sys
 
         #endregion
 
+        public Main()
+        {
+            _settingsStorage = new PluginJsonStorage<Settings>();
+            _settings = _settingsStorage.Load();
+        }
+
         public Control CreateSettingPanel()
         {
             var results = Commands();
@@ -65,11 +74,15 @@ namespace Wox.Plugin.Sys
                     c.Score = score;
                     if (score == titleMatch.Score)
                     {
-                        c.TitleHighlightData = titleMatch.MatchData;
+                        c.TitleHighlightData = _settings.EnableHighlightData
+                                                    ? titleMatch.MatchData
+                                                    : new List<int>();
                     }
                     else 
                     {
-                        c.SubTitleHighlightData = subTitleMatch.MatchData;
+                        c.SubTitleHighlightData = _settings.EnableHighlightData
+                                                    ? subTitleMatch.MatchData
+                                                    : new List<int>();
                     }
                     results.Add(c);
                 }
@@ -261,6 +274,11 @@ namespace Wox.Plugin.Sys
         public string GetTranslatedPluginDescription()
         {
             return context.API.GetTranslation("wox_plugin_sys_plugin_description");
+        }
+
+        public void Save()
+        {
+            _settingsStorage.Save();
         }
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -76,13 +76,13 @@ namespace Wox.Plugin.Sys
                     {
                         c.TitleHighlightData = _settings.EnableHighlightData
                                                     ? titleMatch.MatchData
-                                                    : new List<int>();
+                                                    : null;
                     }
                     else 
                     {
                         c.SubTitleHighlightData = _settings.EnableHighlightData
                                                     ? subTitleMatch.MatchData
-                                                    : new List<int>();
+                                                    : null;
                     }
                     results.Add(c);
                 }

--- a/Plugins/Wox.Plugin.Sys/Main.cs
+++ b/Plugins/Wox.Plugin.Sys/Main.cs
@@ -17,7 +17,7 @@ namespace Wox.Plugin.Sys
     public class Main : IPlugin, ISettingProvider, IPluginI18n, ISavable
     {
         private PluginInitContext context;
-        public static Settings _settings { get; set; }
+        internal static Settings _settings { get; set; }
         private readonly PluginJsonStorage<Settings> _settingsStorage;
 
         #region DllImport

--- a/Plugins/Wox.Plugin.Sys/Settings.cs
+++ b/Plugins/Wox.Plugin.Sys/Settings.cs
@@ -3,6 +3,6 @@ namespace Wox.Plugin.Sys
 {
     internal class Settings
     {
-        internal bool EnableHighlightData { get; set; } = false;
+        public bool EnableHighlightData { get; set; } = false;
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Settings.cs
+++ b/Plugins/Wox.Plugin.Sys/Settings.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Wox.Plugin.Sys
+{
+    public class Settings
+    {
+        public bool EnableHighlightData { get; set; } = false;
+    }
+}

--- a/Plugins/Wox.Plugin.Sys/Settings.cs
+++ b/Plugins/Wox.Plugin.Sys/Settings.cs
@@ -1,8 +1,8 @@
 ﻿
 namespace Wox.Plugin.Sys
 {
-    public class Settings
+    internal class Settings
     {
-        public bool EnableHighlightData { get; set; } = false;
+        internal bool EnableHighlightData { get; set; } = false;
     }
 }

--- a/Plugins/Wox.Plugin.Sys/SysSettings.xaml
+++ b/Plugins/Wox.Plugin.Sys/SysSettings.xaml
@@ -6,7 +6,14 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid Margin="10">
-		<ListView x:Name="lbxCommands" Grid.Row="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Width="130" HorizontalAlignment="Left">
+            <CheckBox Name="HighlightResultsEnabled" Click="HighlightResults_Click" Margin="5" Content="Highlight Results" />
+        </StackPanel>
+		<ListView x:Name="lbxCommands" Grid.Row="1">
 			<ListView.View>
 				<GridView>
 					<GridViewColumn Header="{DynamicResource wox_plugin_sys_command}"  Width="150">

--- a/Plugins/Wox.Plugin.Sys/SysSettings.xaml.cs
+++ b/Plugins/Wox.Plugin.Sys/SysSettings.xaml.cs
@@ -9,10 +9,17 @@ namespace Wox.Plugin.Sys
         {
             InitializeComponent();
 
+            HighlightResultsEnabled.IsChecked = Main._settings.EnableHighlightData;
+
             foreach (var Result in Results)
             {
                 lbxCommands.Items.Add(Result);
             }
+        }
+
+        private void HighlightResults_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Main._settings.EnableHighlightData = HighlightResultsEnabled.IsChecked ?? false;
         }
     }
 }

--- a/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
+++ b/Plugins/Wox.Plugin.Sys/Wox.Plugin.Sys.csproj
@@ -56,6 +56,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="SysSettings.xaml.cs">
       <DependentUpon>SysSettings.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
1. Turns off highlighting by default
2. Implemented plugin level for plugins that have the highlighting

Provides an alternative to issue  https://github.com/jjw24/Wox/issues/171 as solving root cause is too much effort since Wox's search is much better now.

**Original** Wox
![image](https://user-images.githubusercontent.com/26427004/77586849-f35d8480-6f3a-11ea-8990-465ac9c586b7.png)

Since there have been users asking why fonts are different between the original and this version of Wox, this change solves it.

**JJW24 version** with this change
![image](https://user-images.githubusercontent.com/26427004/77586930-1851f780-6f3b-11ea-948b-216b66d4adea.png)

**JJW24 version** with highlighting turned on
![image](https://user-images.githubusercontent.com/26427004/77587228-9910f380-6f3b-11ea-91b7-f5dc0f4b870e.png)
