### PR TITLE
Enable msi extension files to run as different user

### DIFF
--- a/Plugins/Wox.Plugin.Folder/ContextMenuLoader.cs
+++ b/Plugins/Wox.Plugin.Folder/ContextMenuLoader.cs
@@ -194,6 +194,7 @@ namespace Wox.Plugin.Folder
             {
                 case ".exe":
                 case ".bat":
+                case ".msi":
                     return true;
 
                 default:


### PR DESCRIPTION
Enable file extension msi in Folder plugin to run as a different user