### PR TITLE
Add open location prompt after enabling portable

### DIFF
--- a/Wox.Core/Configuration/Portable.cs
+++ b/Wox.Core/Configuration/Portable.cs
@@ -163,21 +163,26 @@ namespace Wox.Core.Configuration
 
             if (DataLocationRoamingDeleteRequired)
             {
-                if(roamingDataPath.LocationExists())
-                    MessageBox.Show("Wox detected you restarted after enabling portable mode, " +
-                                    "your roaming data profile will now be deleted");
-
                 FilesFolders.RemoveFolderIfExists(roamingDataPath);
+
+                if (MessageBox.Show("Wox has detected you enabled portable mode, " +
+                                    "would you like to move it to a different location?", string.Empty,
+                                    MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                {
+                    FilesFolders.OpenLocationInExporer(Constant.RootDirectory);
+
+                    Environment.Exit(0);
+                }
 
                 return;
             }
 
             if(DataLocationPortableDeleteRequired)
             {
-                MessageBox.Show("Wox detected you restarted after disabling portable mode, " +
-                                    "your portable data profile will now be deleted");
-
                 FilesFolders.RemoveFolderIfExists(portableDataPath);
+
+                MessageBox.Show("Wox has detected you disabled portable mode, " +
+                                    "the relevant shortcuts and uninstaller entry have been created");
 
                 return;
             }

--- a/Wox.Plugin/SharedCommands/FilesFolders.cs
+++ b/Wox.Plugin/SharedCommands/FilesFolders.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Windows;
 
@@ -106,6 +107,23 @@ namespace Wox.Plugin.SharedCommands
         public static bool FileExits(this string filePath)
         {
             return File.Exists(filePath);
+        }
+
+        public static void OpenLocationInExporer(string location)
+        {
+            try
+            {
+                if (LocationExists(location))
+                    Process.Start(location);
+            }
+            catch (Exception e)
+            {
+#if DEBUG
+                throw e;
+#else
+                MessageBox.Show(string.Format("Unable to open location {0}, please check if it exists", location));
+#endif
+            }
         }
     }
 }


### PR DESCRIPTION
Prompt the user if they want to open the location of the Wox folder to move it somewhere else after they enable portable mode.

From discussion here: https://github.com/jjw24/Wox/issues/175