### PR TITLE
Sub-string match scoring- Change scoring bonus applicable from 3 to 4 chars

### DIFF
--- a/Wox.Infrastructure/StringMatcher.cs
+++ b/Wox.Infrastructure/StringMatcher.cs
@@ -211,8 +211,11 @@ namespace Wox.Infrastructure
 
             if (allSubstringsContainedInCompareString)
             {
-                int count = query.Count(c => !char.IsWhiteSpace(c));
-                int factor = count < 4 ? 10 : 5;
+                var count = query.Count(c => !char.IsWhiteSpace(c));
+
+                //10 per char is too much for long query strings, this limitation is to avoid where long strings will override the other results too much
+                var factor = count < 5 ? 10 : 5;
+
                 score += factor * count;
             }
 

--- a/Wox.Test/FuzzyMatcherTest.cs
+++ b/Wox.Test/FuzzyMatcherTest.cs
@@ -18,6 +18,7 @@ namespace Wox.Test
         private const string LastIsChrome = "Last is chrome";
         private const string OneOneOneOne = "1111";
         private const string MicrosoftSqlServerManagementStudio = "Microsoft SQL Server Management Studio";
+        private const string VisualStudioCode = "Visual Studio Code";
 
         public List<string> GetSearchStrings()
             => new List<string>
@@ -195,6 +196,9 @@ namespace Wox.Test
         [TestCase("ch r", "Change settings for text-to-speech and for speech recognition (if installed).", StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("a test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
         [TestCase("test", "This is a test", StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("cod", VisualStudioCode, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("code", VisualStudioCode, StringMatcher.SearchPrecisionScore.Regular, true)]
+        [TestCase("codes", "Visual Studio Codes", StringMatcher.SearchPrecisionScore.Regular, true)]
         public void WhenGivenQueryShouldReturnResultsContainingAllQuerySubstrings(
             string queryString,
             string compareString,


### PR DESCRIPTION
Problem context:
Previously search results such as searching 'code' for 'Visual Studio Codes' does not make the regular precision cut as it does not get the bonus, where as both 'cod' and 'codes' do make the cut.

Solution:
Extend the applicable bonus scoring to cover 4 chars as well. 5 chars already has enough scoring to make regular precision so 4 is ideal

Closes #181 , #163 